### PR TITLE
e2e tests. open json file

### DIFF
--- a/packages/web-app-json-viewer/tests/e2e/jsonViewer.spec.ts
+++ b/packages/web-app-json-viewer/tests/e2e/jsonViewer.spec.ts
@@ -1,0 +1,27 @@
+import { test, Page, expect } from '@playwright/test'
+import { FilesAppBar } from '../../../../support/pages/filesAppBarActions'
+import { FilesPage } from '../../../../support/pages/filesPage'
+import { loginAsUser, logout } from '../../../../support/helpers/authHelper'
+
+let adminPage: Page
+
+test.beforeEach(async ({ browser }) => {
+  const admin = await loginAsUser(browser, 'admin', 'admin')
+  adminPage = admin.page
+})
+
+test.afterEach(async () => {
+  const file = new FilesPage(adminPage)
+  await file.deleteAllFromPersonal()
+  await logout(adminPage)
+})
+
+test('open json file', async () => {
+  const uploadFile = new FilesAppBar(adminPage)
+  await uploadFile.uploadFile('file.json')
+
+  const file = new FilesPage(adminPage)
+  await file.openJsonFile('file.json')
+  await expect(adminPage).toHaveURL(/json-viewer/)
+  await expect(adminPage.locator('#json-viewer')).toBeVisible()
+})

--- a/packages/web-app-json-viewer/vite.config.ts
+++ b/packages/web-app-json-viewer/vite.config.ts
@@ -11,5 +11,8 @@ export default defineConfig({
         entryFileNames: 'json-viewer.js'
       }
     }
+  },
+  test: {
+    exclude: ['**/e2e/**']
   }
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -77,6 +77,21 @@ export default defineConfig({
       name: 'external-sites-webkit',
       testDir: './packages/web-app-external-sites/tests/e2e',
       use: { ...devices['Desktop Safari'], browserName: 'webkit', ignoreHTTPSErrors: true }
+    },
+    {
+      name: 'json-viewer-chromium',
+      testDir: './packages/web-app-json-viewer/tests/e2e',
+      use: { ...devices['Desktop Chrome'], browserName: 'chromium', ignoreHTTPSErrors: true }
+    },
+    {
+      name: 'json-viewer-firefox',
+      testDir: './packages/web-app-json-viewer/tests/e2e',
+      use: { ...devices['Desktop Firefox'], browserName: 'firefox', ignoreHTTPSErrors: true }
+    },
+    {
+      name: 'json-viewer-webkit',
+      testDir: './packages/web-app-json-viewer/tests/e2e',
+      use: { ...devices['Desktop Safari'], browserName: 'webkit', ignoreHTTPSErrors: true }
     }
 
     /* Test against mobile viewports. */

--- a/support/filesForUpload/file.json
+++ b/support/filesForUpload/file.json
@@ -1,0 +1,14 @@
+{
+    "value": [
+        {
+            "appRoles": [
+                {
+                    "displayName": "Space Admin",
+                    "id": "2aadd357-682c-406b-8874-293091995fdd"
+                }
+            ],
+            "displayName": "OpenCloud",
+            "id": "d67265e7-86c9-4c46-9428-286c02c5814b"
+        }
+    ]
+}

--- a/support/pages/filesPage.ts
+++ b/support/pages/filesPage.ts
@@ -5,11 +5,13 @@ export class FilesPage {
   readonly uploadBtn: Locator
   readonly extractHereBtnBtn: Locator
   readonly selectAllCheckbox: Locator
+  readonly openInJsonViewerBtn: Locator
 
   constructor(page: Page) {
     this.page = page
     this.extractHereBtnBtn = this.page.locator('.context-menu .oc-files-actions-unzip-archive')
     this.selectAllCheckbox = this.page.getByLabel('Select all')
+    this.openInJsonViewerBtn = this.page.locator('.oc-files-actions-json-viewer-trigger')
   }
 
   getResourceNameSelector(resource: string): Locator {
@@ -37,5 +39,18 @@ export class FilesPage {
   async openFolder(folder: string) {
     const folderLocator = this.getResourceNameSelector(folder)
     await folderLocator.click()
+  }
+
+  async openJsonFile(file: string) {
+    const fileLocator = this.getResourceNameSelector(file)
+    await fileLocator.click({ button: 'right' })
+
+    await Promise.all([
+      this.page.waitForResponse(
+        (resp) =>
+          resp.status() === 200 && resp.request().method() === 'GET' && resp.url().includes(file)
+      ),
+      this.openInJsonViewerBtn.click()
+    ])
   }
 }


### PR DESCRIPTION
related #53

![image](https://github.com/user-attachments/assets/c4957817-f143-459a-a5fb-f15148333b0b)


@JammingBen  
- I see that we can't edit `json` file in Json Viewer. somehow it is not convenient, can we add this feature?
- so we can't create a json file directly, only open it. can we add this: 
<img width="355" alt="Screenshot 2025-03-11 at 16 43 33" src="https://github.com/user-attachments/assets/39d97bea-0548-4c7b-bf4e-4ccb884843ba" />

