### PR TITLE
chore: group renovate dev dependencies

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,8 +1,14 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:recommended"
-    ],
-    "prConcurrentLimit": 15,
-    "postUpdateOptions": ["pnpmDedupe"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "prConcurrentLimit": 15,
+  "postUpdateOptions": ["pnpmDedupe"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)",
+      "groupSlug": "dev-dependencies"
+    }
+  ]
 }


### PR DESCRIPTION
There is no need for renovate to create a separate PR for every (minor) dev dependency upgrade, hence group them together.