### PR TITLE
fix(unzip): extracting archives

### DIFF
--- a/packages/web-app-unzip/package.json
+++ b/packages/web-app-unzip/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@opencloud-eu/web-client": "^2.0.0",
     "@opencloud-eu/web-pkg": "^2.0.0",
-    "p-queue": "^8.0.0",
     "uuid": "^11.0.0",
     "vue": "^3.4.21",
     "vue3-gettext": "^2.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,9 +200,6 @@ importers:
       '@opencloud-eu/web-pkg':
         specifier: ^2.0.0
         version: 2.0.0(@codemirror/view@6.36.3)(@lezer/common@1.2.3)(@vue/compiler-sfc@3.5.13)(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
-      p-queue:
-        specifier: ^8.0.0
-        version: 8.1.0
       uuid:
         specifier: ^11.0.0
         version: 11.1.0


### PR DESCRIPTION
Fixes extracting archives by removing p-queue. It seems to cause trouble in connection with the extraction worker and is not really needed here since network requests are limited by Uppy already.