### PR TITLE
create unique user for each test

### DIFF
--- a/.woodpecker/e2e-tests.yaml
+++ b/.woodpecker/e2e-tests.yaml
@@ -46,28 +46,9 @@ steps:
       - pnpm exec playwright install chromium
       - cp -R /root/.cache/ms-playwright /woodpecker/playwright-cache
 
-  # TODO: use one step with "pnpm test:e2e --project='*-chromium'" when tests can run parallel
-  - name: e2e-draw-io
+  - name: e2e-tests
     image: *node_image
     commands:
       - mkdir -p /root/.cache
       - cp -R /woodpecker/playwright-cache /root/.cache/ms-playwright
-      - "BASE_URL_OC=https://opencloud:9200 pnpm test:e2e --project='draw-io-chromium'"
-  - name: e2e-external-sites
-    image: *node_image
-    commands:
-      - mkdir -p /root/.cache
-      - cp -R /woodpecker/playwright-cache /root/.cache/ms-playwright
-      - "BASE_URL_OC=https://opencloud:9200 pnpm test:e2e --project='external-sites-chromium'"
-  - name: e2e-json-viewer
-    image: *node_image
-    commands:
-      - mkdir -p /root/.cache
-      - cp -R /woodpecker/playwright-cache /root/.cache/ms-playwright
-      - "BASE_URL_OC=https://opencloud:9200 pnpm test:e2e --project='json-viewer-chromium'"
-  - name: e2e-unzip
-    image: *node_image
-    commands:
-      - mkdir -p /root/.cache
-      - cp -R /woodpecker/playwright-cache /root/.cache/ms-playwright
-      - "BASE_URL_OC=https://opencloud:9200 pnpm test:e2e --project='unzip-chromium'"
+      - "BASE_URL_OC=https://opencloud:9200 pnpm test:e2e --project='*-chromium'"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typescript": "5.8.2",
     "vite": "6.2.4",
     "vitest": "3.1.1",
+    "uuid": "^11.0.0",
     "vitest-mock-extended": "3.0.1",
     "vue-tsc": "2.2.8",
     "vue3-gettext": "^2.4.0"

--- a/packages/web-app-draw-io/tests/e2e/createDrawIo.spec.ts
+++ b/packages/web-app-draw-io/tests/e2e/createDrawIo.spec.ts
@@ -2,25 +2,26 @@ import { test, Page, expect } from '@playwright/test'
 import { AppSwitcher } from '../../../../support/pages/appSwitcher'
 import { DrawIoPage } from '../../../../support/pages/drawIoPage'
 import { loginAsUser, logout } from '../../../../support/helpers/authHelper'
+import { createRandomUser } from '../../../../support/helpers/api/apiHelper'
 
-let adminPage: Page
+let userPage: Page
 
 test.beforeEach(async ({ browser }) => {
-  const admin = await loginAsUser(browser, 'admin', 'admin')
-  adminPage = admin.page
+  const user = await createRandomUser()
+  userPage = (await loginAsUser(browser, user.username, user.password)).page
 })
 
 test.afterEach(async () => {
-  await logout(adminPage)
+  await logout(userPage)
 })
 
 test('create drawio file', async () => {
-  const appSwitcher = new AppSwitcher(adminPage)
+  const appSwitcher = new AppSwitcher(userPage)
   await appSwitcher.clickAppSwitcher()
   await appSwitcher.createDrawIoFile()
-  await expect(adminPage).toHaveURL(/.*draw-io/)
+  await expect(userPage).toHaveURL(/.*draw-io/)
 
-  const darwIo = new DrawIoPage(adminPage)
+  const darwIo = new DrawIoPage(userPage)
   await darwIo.addContent()
   await darwIo.save()
   await darwIo.close()

--- a/packages/web-app-draw-io/tests/e2e/createDrawIo.spec.ts
+++ b/packages/web-app-draw-io/tests/e2e/createDrawIo.spec.ts
@@ -21,8 +21,8 @@ test('create drawio file', async () => {
   await appSwitcher.createDrawIoFile()
   await expect(userPage).toHaveURL(/.*draw-io/)
 
-  const darwIo = new DrawIoPage(userPage)
-  await darwIo.addContent()
-  await darwIo.save()
-  await darwIo.close()
+  const drawIo = new DrawIoPage(userPage)
+  await drawIo.addContent()
+  await drawIo.save()
+  await drawIo.close()
 })

--- a/packages/web-app-external-sites/tests/e2e/openExternalSite.spec.ts
+++ b/packages/web-app-external-sites/tests/e2e/openExternalSite.spec.ts
@@ -1,24 +1,25 @@
 import { test, Page, expect } from '@playwright/test'
 import { AppSwitcher } from '../../../../support/pages/appSwitcher'
 import { loginAsUser, logout } from '../../../../support/helpers/authHelper'
+import { createRandomUser } from '../../../../support/helpers/api/apiHelper'
 
-let adminPage: Page
+let userPage: Page
 
 test.beforeEach(async ({ browser }) => {
-  const admin = await loginAsUser(browser, 'admin', 'admin')
-  adminPage = admin.page
+  const user = await createRandomUser()
+  userPage = (await loginAsUser(browser, user.username, user.password)).page
 })
 
 test.afterEach(async () => {
-  await logout(adminPage)
+  await logout(userPage)
 })
 
 test('open external site', async () => {
-  const appSwitcher = new AppSwitcher(adminPage)
+  const appSwitcher = new AppSwitcher(userPage)
   await appSwitcher.clickAppSwitcher()
 
   const [newPage] = await Promise.all([
-    adminPage.waitForEvent('popup'),
+    userPage.waitForEvent('popup'),
     appSwitcher.openExternalSite('OpenCloud')
   ])
   await expect(newPage).toHaveURL(/https:\/\/opencloud\.eu/)

--- a/packages/web-app-json-viewer/tests/e2e/jsonViewer.spec.ts
+++ b/packages/web-app-json-viewer/tests/e2e/jsonViewer.spec.ts
@@ -2,26 +2,25 @@ import { test, Page, expect } from '@playwright/test'
 import { FilesAppBar } from '../../../../support/pages/filesAppBarActions'
 import { FilesPage } from '../../../../support/pages/filesPage'
 import { loginAsUser, logout } from '../../../../support/helpers/authHelper'
+import { createRandomUser } from '../../../../support/helpers/api/apiHelper'
 
-let adminPage: Page
+let userPage: Page
 
 test.beforeEach(async ({ browser }) => {
-  const admin = await loginAsUser(browser, 'admin', 'admin')
-  adminPage = admin.page
+  const user = await createRandomUser()
+  userPage = (await loginAsUser(browser, user.username, user.password)).page
 })
 
 test.afterEach(async () => {
-  const file = new FilesPage(adminPage)
-  await file.deleteAllFromPersonal()
-  await logout(adminPage)
+  await logout(userPage)
 })
 
 test('open json file', async () => {
-  const uploadFile = new FilesAppBar(adminPage)
+  const uploadFile = new FilesAppBar(userPage)
   await uploadFile.uploadFile('file.json')
 
-  const file = new FilesPage(adminPage)
+  const file = new FilesPage(userPage)
   await file.openJsonFile('file.json')
-  await expect(adminPage).toHaveURL(/json-viewer/)
-  await expect(adminPage.locator('#json-viewer')).toBeVisible()
+  await expect(userPage).toHaveURL(/json-viewer/)
+  await expect(userPage.locator('#json-viewer')).toBeVisible()
 })

--- a/packages/web-app-unzip/tests/e2e/extractZip.spec.ts
+++ b/packages/web-app-unzip/tests/e2e/extractZip.spec.ts
@@ -2,30 +2,29 @@ import { test, Page, expect } from '@playwright/test'
 import { FilesAppBar } from '../../../../support/pages/filesAppBarActions'
 import { FilesPage } from '../../../../support/pages/filesPage'
 import { loginAsUser, logout } from '../../../../support/helpers/authHelper'
+import { createRandomUser } from '../../../../support/helpers/api/apiHelper'
 
-let adminPage: Page
+let userPage: Page
 
 test.beforeEach(async ({ browser }) => {
-  const admin = await loginAsUser(browser, 'admin', 'admin')
-  adminPage = admin.page
+  const user = await createRandomUser()
+  userPage = (await loginAsUser(browser, user.username, user.password)).page
 })
 
 test.afterEach(async () => {
-  const file = new FilesPage(adminPage)
-  await file.deleteAllFromPersonal()
-  await logout(adminPage)
+  await logout(userPage)
 })
 
 test('extract zip file', async () => {
-  const uploadFile = new FilesAppBar(adminPage)
+  const uploadFile = new FilesAppBar(userPage)
   await uploadFile.uploadFile('data.zip')
 
-  const file = new FilesPage(adminPage)
+  const file = new FilesPage(userPage)
   await file.extractZip('data.zip')
 
   await file.openFolder('data')
   await expect(
-    adminPage.locator('span.oc-resource-basename', { hasText: 'logo-wide' })
+    userPage.locator('span.oc-resource-basename', { hasText: 'logo-wide' })
   ).toBeVisible()
-  await expect(adminPage.locator('span.oc-resource-basename', { hasText: 'lorem' })).toBeVisible()
+  await expect(userPage.locator('span.oc-resource-basename', { hasText: 'lorem' })).toBeVisible()
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,12 +39,12 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], browserName: 'chromium', ignoreHTTPSErrors: true }
     },
     {
-      name: 'drawIO-firefox',
+      name: 'draw-io-firefox',
       testDir: './packages/web-app-draw-io/tests/e2e',
       use: { ...devices['Desktop Firefox'], browserName: 'firefox', ignoreHTTPSErrors: true }
     },
     {
-      name: 'drawIO-webkit',
+      name: 'draw-io-webkit',
       testDir: './packages/web-app-draw-io/tests/e2e',
       use: { ...devices['Desktop Safari'], browserName: 'webkit', ignoreHTTPSErrors: true }
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       typescript:
         specifier: 5.8.2
         version: 5.8.2
+      uuid:
+        specifier: ^11.0.0
+        version: 11.1.0
       vite:
         specifier: 6.2.4
         version: 6.2.4(@types/node@22.13.16)(sass@1.80.7)

--- a/support/helpers/api/apiHelper.ts
+++ b/support/helpers/api/apiHelper.ts
@@ -1,0 +1,40 @@
+import { request } from '@playwright/test'
+import { getAdminToken } from './getToken'
+import config from '../../../playwright.config'
+import { v4 as uuidv4 } from 'uuid'
+
+const API_URL = config.use.baseURL + '/graph/v1.0/users'
+const adminUsername = process.env.ADMIN_USERNAME ?? 'admin'
+const adminPassword = process.env.ADMIN_PASSWORD ?? 'admin'
+
+export async function createUser(username: string, password: string) {
+  const adminToken = await getAdminToken(adminUsername, adminPassword)
+
+  const context = await request.newContext()
+  const response = await context.post(API_URL, {
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      'Content-Type': 'application/json'
+    },
+    data: {
+      onPremisesSamAccountName: username,
+      displayName: username,
+      mail: `${username}@test.com`,
+      passwordProfile: { password }
+    }
+  })
+
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to create user ${username}: ${response.status()} - ${await response.text()}`
+    )
+  }
+
+  const data = await response.json()
+  return { id: data.id, username, password }
+}
+
+export async function createRandomUser() {
+  const uniquePrefix = uuidv4().substring(0, 4)
+  return await createUser(`Alice-${uniquePrefix}`, '123')
+}

--- a/support/helpers/api/getToken.ts
+++ b/support/helpers/api/getToken.ts
@@ -1,0 +1,88 @@
+import { request } from '@playwright/test'
+import config from '../../../playwright.config'
+
+const baseUrl = config.use.baseURL
+const clientId = 'web'
+
+const logonUrl = `${baseUrl}/signin/v1/identifier/_/logon`
+const tokenUrl = `${baseUrl}/konnect/v1/token`
+const redirectUrl = `${baseUrl}/oidc-callback.html`
+
+export async function getAdminToken(username: string, password: string): Promise<string> {
+  const context = await request.newContext()
+
+  const continueUrl = await logonUser(context, username, password)
+  const code = await getAuthorizationCode(context, continueUrl)
+  return await requestAccessToken(context, code)
+}
+
+async function logonUser(context: any, username: string, password: string): Promise<string> {
+  const response = await context.post(logonUrl, {
+    headers: {
+      'Kopano-Konnect-XSRF': '1',
+      Referer: baseUrl,
+      'Content-Type': 'application/json'
+    },
+    data: JSON.stringify({
+      params: [username, password, '1'],
+      hello: {
+        scope: 'openid profile email',
+        client_id: clientId,
+        redirect_uri: redirectUrl,
+        flow: 'oidc'
+      }
+    })
+  })
+
+  if (response.status() !== 200) {
+    throw new Error(`Logon failed: ${response.statusText()}`)
+  }
+
+  const data = (await response.json()) as { hello: { continue_uri: string } }
+  return data.hello.continue_uri
+}
+
+async function getAuthorizationCode(context: any, continueUrl: string): Promise<string> {
+  const authParams = new URLSearchParams({
+    client_id: clientId,
+    prompt: 'none',
+    redirect_uri: redirectUrl,
+    response_mode: 'query',
+    response_type: 'code',
+    scope: 'openid profile offline_access email'
+  })
+
+  const response = await context.get(continueUrl, {
+    params: authParams,
+    maxRedirects: 0
+  })
+
+  if (response.status() !== 302) {
+    throw new Error(`Authorization failed: Expected 302 but received ${response.status()}`)
+  }
+
+  const location = response.headers()['location'] || ''
+  const code = new URLSearchParams(location.split('?')[1]).get('code')
+  if (!code) throw new Error('Missing auth code')
+
+  return code
+}
+
+async function requestAccessToken(context: any, code: string): Promise<string> {
+  const response = await context.post(tokenUrl, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    form: {
+      client_id: clientId,
+      code,
+      redirect_uri: redirectUrl,
+      grant_type: 'authorization_code'
+    }
+  })
+
+  if (response.status() !== 200) {
+    throw new Error(`Token request failed: ${response.statusText()}`)
+  }
+
+  const { access_token } = (await response.json()) as { access_token: string }
+  return access_token
+}

--- a/support/helpers/api/getToken.ts
+++ b/support/helpers/api/getToken.ts
@@ -1,4 +1,4 @@
-import { request } from '@playwright/test'
+import { request, APIRequestContext } from '@playwright/test'
 import config from '../../../playwright.config'
 
 const baseUrl = config.use.baseURL
@@ -16,7 +16,11 @@ export async function getAdminToken(username: string, password: string): Promise
   return await requestAccessToken(context, code)
 }
 
-async function logonUser(context: any, username: string, password: string): Promise<string> {
+async function logonUser(
+  context: APIRequestContext,
+  username: string,
+  password: string
+): Promise<string> {
   const response = await context.post(logonUrl, {
     headers: {
       'Kopano-Konnect-XSRF': '1',
@@ -42,7 +46,10 @@ async function logonUser(context: any, username: string, password: string): Prom
   return data.hello.continue_uri
 }
 
-async function getAuthorizationCode(context: any, continueUrl: string): Promise<string> {
+async function getAuthorizationCode(
+  context: APIRequestContext,
+  continueUrl: string
+): Promise<string> {
   const authParams = new URLSearchParams({
     client_id: clientId,
     prompt: 'none',
@@ -68,7 +75,7 @@ async function getAuthorizationCode(context: any, continueUrl: string): Promise<
   return code
 }
 
-async function requestAccessToken(context: any, code: string): Promise<string> {
+async function requestAccessToken(context: APIRequestContext, code: string): Promise<string> {
   const response = await context.post(tokenUrl, {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     form: {


### PR DESCRIPTION
One admin user was used in the tests. It was enough for the start, but now, when we run all tests with one user, we have conflicts when deleting data etc.

I added: 
- getting userToken to use api
- creating user via api
- creating randomUser via api

how to tests: 
- run all tests in chromium `pnpm test:e2e --project='*-chromium'` 
- run all tests `pnpm test:e2e` 


Here are my runs of the tests (no more conflicts)
![Screenshot 2025-04-01 at 19 27 22](https://github.com/user-attachments/assets/b2995c4a-2ccd-4180-915b-5c60f40be475)
