### PR TITLE
ci: use woodpecker node image instead of a custom one

### DIFF
--- a/.woodpecker/check-types.yaml
+++ b/.woodpecker/check-types.yaml
@@ -5,14 +5,10 @@ when:
   - event: [pull_request, manual, tag]
 
 variables:
-  - &node_image 'owncloudci/nodejs:20'
+  - &node_image 'woodpeckerci/plugin-node-pm:latest'
 
 steps:
-  - name: pnpm-install
-    image: *node_image
-    commands:
-      - pnpm install
   - name: check-types
     image: *node_image
-    commands:
-      - pnpm check:types
+    settings:
+      run: check:types

--- a/.woodpecker/format.yaml
+++ b/.woodpecker/format.yaml
@@ -5,14 +5,10 @@ when:
   - event: [pull_request, manual, tag]
 
 variables:
-  - &node_image 'owncloudci/nodejs:20'
+  - &node_image 'woodpeckerci/plugin-node-pm:latest'
 
 steps:
-  - name: pnpm-install
-    image: *node_image
-    commands:
-      - pnpm install
   - name: format
     image: *node_image
-    commands:
-      - pnpm format:check
+    settings:
+      run: format:check

--- a/.woodpecker/lint.yaml
+++ b/.woodpecker/lint.yaml
@@ -5,14 +5,10 @@ when:
   - event: [pull_request, manual, tag]
 
 variables:
-  - &node_image 'owncloudci/nodejs:20'
+  - &node_image 'woodpeckerci/plugin-node-pm:latest'
 
 steps:
-  - name: pnpm-install
-    image: *node_image
-    commands:
-      - pnpm install
   - name: lint
     image: *node_image
-    commands:
-      - pnpm lint
+    settings:
+      run: lint

--- a/.woodpecker/unit-tests.yaml
+++ b/.woodpecker/unit-tests.yaml
@@ -5,14 +5,10 @@ when:
   - event: [pull_request, manual, tag]
 
 variables:
-  - &node_image 'owncloudci/nodejs:20'
+  - &node_image 'woodpeckerci/plugin-node-pm:latest'
 
 steps:
-  - name: pnpm-install
-    image: *node_image
-    commands:
-      - pnpm install
   - name: unit-tests
     image: *node_image
-    commands:
-      - pnpm test:unit
+    settings:
+      run: test:unit


### PR DESCRIPTION
This is possible for most simple workflows with one exception being the e2e tests. They need a more sophisticated image be able to run.