### PR TITLE
feat: external sites dashboard

### DIFF
--- a/packages/web-app-external-sites/package.json
+++ b/packages/web-app-external-sites/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "pnpm vite build",
     "build:w": "pnpm vite build --watch --mode development",
+    "check:types": "vue-tsc --noEmit",
     "test:unit": "NODE_OPTIONS=--unhandled-rejections=throw vitest"
   },
   "devDependencies": {

--- a/packages/web-app-external-sites/src/App.vue
+++ b/packages/web-app-external-sites/src/App.vue
@@ -5,12 +5,20 @@
 </template>
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { useGettext } from 'vue3-gettext'
 
 export default defineComponent({
   name: 'ExternalSite',
   props: {
     name: { type: String, required: true },
     url: { type: String, required: true }
+  },
+  setup() {
+    const { $gettext } = useGettext()
+
+    return {
+      $gettext
+    }
   }
 })
 </script>

--- a/packages/web-app-external-sites/src/ExternalSitesDashboard.vue
+++ b/packages/web-app-external-sites/src/ExternalSitesDashboard.vue
@@ -1,0 +1,68 @@
+<template>
+  <main id="external-sites-dashboard" class="oc-pt-m oc-pb-l oc-flex oc-flex-center">
+    <div class="page">
+      <h1 class="title oc-mb-rm" v-text="$gettext('Dashboard')" />
+      <!-- FIXME: how to do this properly?! -->
+      <br />
+      <br />
+      <dashboard-group :group="standaloneGroup" />
+
+      <template v-for="group in groups" :key="group.name">
+        <dashboard-group :group="group" />
+      </template>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import DashboardGroup from './components/DashboardGroup.vue'
+import { computed, PropType } from 'vue'
+import {
+  ExternalSiteOrSiteGroup,
+  ExternalSiteGroup,
+  ExternalSite,
+  isExternalSiteGroup
+} from './types'
+import { useGettext } from 'vue3-gettext'
+
+const { $gettext } = useGettext()
+
+const props = defineProps({
+  sites: {
+    type: Array as PropType<ExternalSiteOrSiteGroup[]>,
+    required: true
+  }
+})
+
+const standaloneGroup = computed((): ExternalSiteGroup => {
+  return {
+    // TODO: sort by priority?
+    sites: props.sites.filter((item) => !isExternalSiteGroup(item)) as ExternalSite[]
+  }
+})
+
+const groups = computed((): ExternalSiteGroup[] => {
+  // TODO: sort by priority?
+  return props.sites.filter((item) => isExternalSiteGroup(item))
+})
+</script>
+
+<style lang="scss">
+#external-sites-dashboard {
+  overflow-y: auto;
+
+  .title {
+    border-bottom: 0.5px solid var(--oc-role-outline-variant);
+  }
+
+  .page {
+    width: 80rem;
+
+    @media (max-width: 1200px) {
+      width: 100%;
+      padding-left: var(--oc-space-medium);
+      padding-right: var(--oc-space-medium);
+    }
+  }
+}
+</style>

--- a/packages/web-app-external-sites/src/components/DashboardGroup.vue
+++ b/packages/web-app-external-sites/src/components/DashboardGroup.vue
@@ -1,0 +1,33 @@
+<template>
+  <h2 v-if="group.name" class="oc-flex oc-flex-middle oc-mb-s">
+    {{ group.name }}
+  </h2>
+  <div class="link-list oc-mb-m">
+    <oc-list class="links">
+      <dashboard-link v-for="site in group.sites" :key="site.name" :site="site" />
+    </oc-list>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { PropType } from 'vue'
+import DashboardLink from './DashboardLink.vue'
+import { ExternalSiteGroup } from '../types'
+
+defineProps({
+  group: {
+    type: Object as PropType<ExternalSiteGroup>,
+    required: true
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.link-list {
+  .links {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 2rem;
+  }
+}
+</style>

--- a/packages/web-app-external-sites/src/components/DashboardLink.vue
+++ b/packages/web-app-external-sites/src/components/DashboardLink.vue
@@ -1,0 +1,54 @@
+<template>
+  <li class="tile oc-card oc-card-default oc-card-rounded">
+    <a :href="site.url" target="_blank">
+      <div class="tile-body oc-card-body oc-p">
+        <div class="tile-content oc-flex oc-flex-middle">
+          <div class="tile-icon">
+            <oc-icon v-if="site.icon" :name="site.icon" :color="site.color" size="xlarge" />
+          </div>
+          <div>
+            <h3 class="oc-my-s oc-text-truncate mark-element tile-title">
+              {{ site.name }}
+            </h3>
+            <p class="oc-my-s mark-element">{{ site.description }}</p>
+          </div>
+        </div>
+      </div>
+    </a>
+  </li>
+</template>
+
+<script setup lang="ts">
+import { type PropType } from 'vue'
+import { ExternalSite } from '../types'
+
+defineProps({
+  site: {
+    type: Object as PropType<ExternalSite>,
+    required: true
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.tile {
+  overflow: hidden;
+  background-color: var(--oc-role-surface-container) !important;
+  box-shadow: none;
+  height: 100%;
+  display: flex;
+  flex-flow: column;
+  outline: 0.5px solid var(--oc-role-outline-variant);
+
+  .tile-icon {
+    margin-right: var(--oc-space-medium);
+  }
+
+  .tile-body {
+    display: flex;
+    flex-flow: column;
+    justify-content: space-between;
+    height: 100%;
+  }
+}
+</style>

--- a/packages/web-app-external-sites/src/index.ts
+++ b/packages/web-app-external-sites/src/index.ts
@@ -1,11 +1,13 @@
 import { urlJoin } from '@opencloud-eu/web-client'
 import { AppMenuItemExtension, defineWebApplication } from '@opencloud-eu/web-pkg'
 import translations from '../l10n/translations.json'
-import App from './App.vue'
 import { useGettext } from 'vue3-gettext'
 import { computed, h } from 'vue'
 import { RouteRecordRaw } from 'vue-router'
-import { ExternalSitesConfigSchema } from './types'
+import { ExternalSitesConfigSchema, isExternalSite, ExternalSite } from './types'
+
+import App from './App.vue'
+import Dashboard from './ExternalSitesDashboard.vue'
 
 export default defineWebApplication({
   setup({ applicationConfig }) {
@@ -13,10 +15,12 @@ export default defineWebApplication({
 
     const appId = 'external-sites'
 
-    const { sites = [] } = ExternalSitesConfigSchema.parse(applicationConfig)
+    const { dashboard, sites = [] } = ExternalSitesConfigSchema.parse(applicationConfig)
 
     const routes: RouteRecordRaw[] = []
-    const internalSites = sites.filter((s) => s.target === 'embedded')
+    const internalSites = sites.filter(
+      (s) => isExternalSite(s) && s.target === 'embedded'
+    ) as ExternalSite[]
     internalSites.forEach(({ name, url }) => {
       routes.push({
         path: urlJoin(encodeURIComponent(name).toLowerCase()),
@@ -31,21 +35,45 @@ export default defineWebApplication({
     })
 
     const menuItems = computed<AppMenuItemExtension[]>(() =>
-      sites.map((s) => {
-        return {
-          id: `${appId}-${s.name}`,
-          type: 'appMenuItem',
-          label: () => $gettext(s.name),
-          color: s.color,
-          icon: s.icon,
-          priority: s.priority,
-          ...(s.target === 'embedded' && {
-            path: urlJoin(appId, encodeURIComponent(s.name).toLowerCase())
-          }),
-          ...(s.target === 'external' && { url: s.url })
+      sites
+        .filter((s) => isExternalSite(s))
+        .map((s) => {
+          return {
+            id: `${appId}-${s.name}`,
+            type: 'appMenuItem',
+            label: () => $gettext(s.name),
+            color: s.color,
+            icon: s.icon,
+            priority: s.priority,
+            ...(s.target === 'embedded' && {
+              path: urlJoin(appId, encodeURIComponent(s.name).toLowerCase())
+            }),
+            ...(s.target === 'external' && { url: s.url })
+          }
+        })
+    )
+
+    if (dashboard?.enabled) {
+      routes.push({
+        path: '/',
+        component: h(Dashboard, { sites }),
+        name: `${appId}-dashboard`,
+        meta: {
+          authContext: 'user',
+          title: dashboard.title || $gettext('Dashboard'),
+          patchCleanPath: true
         }
       })
-    )
+
+      menuItems.value.push({
+        id: `${appId}-dashboard`,
+        type: 'appMenuItem',
+        label: () => dashboard.title || $gettext('Dashboard'),
+        color: 'pink', //s.color,
+        icon: 'grid',
+        path: '/external-sites'
+      })
+    }
 
     return {
       appInfo: {

--- a/packages/web-app-external-sites/src/types.ts
+++ b/packages/web-app-external-sites/src/types.ts
@@ -6,9 +6,39 @@ export const ExternalSiteSchema = z.object({
   url: z.string(),
   color: z.string().optional(),
   icon: z.string().optional(),
-  priority: z.number().optional()
+  priority: z.number().optional(),
+  description: z.string().optional()
 })
 
-export const ExternalSitesConfigSchema = z.object({
+export type ExternalSite = z.infer<typeof ExternalSiteSchema>
+
+export const isExternalSite = (item: ExternalSiteOrSiteGroup): item is ExternalSite => {
+  return (item as ExternalSiteGroup).sites === undefined
+}
+
+export const ExternalSiteGroupSchema = z.object({
+  name: z.string().optional(),
   sites: z.array(ExternalSiteSchema)
+})
+
+export type ExternalSiteGroup = z.infer<typeof ExternalSiteGroupSchema>
+
+export const ExternalSiteOrSiteGroupSchema = z.union([ExternalSiteSchema, ExternalSiteGroupSchema])
+
+export type ExternalSiteOrSiteGroup = z.infer<typeof ExternalSiteOrSiteGroupSchema>
+
+export const isExternalSiteGroup = (item: ExternalSiteOrSiteGroup): item is ExternalSiteGroup => {
+  return (item as ExternalSiteGroup).sites !== undefined
+}
+
+export const ExternalSitesConfigSchema = z.object({
+  dashboard: z
+    .object({
+      enabled: z.boolean().default(true),
+      title: z.string().optional()
+    })
+    .default({
+      enabled: true
+    }),
+  sites: z.array(ExternalSiteOrSiteGroupSchema)
 })


### PR DESCRIPTION
# Description
Implement a dashboard showing an overview over external links.

# Motivation
Personally I want to use it to show services on my local network, see screenshot.


# Screenshot
<img width="1370" height="724" alt="Screenshot_20250804_140527" src="https://github.com/user-attachments/assets/2aac8c63-b29b-4257-942a-98265be19fad" />

`apps.yaml` for ^ looks like this:
```yaml
external-sites:
  config:
    sites:
      - name: 'Plex'
        url: 'https://plex.xxx.xxx'
        target: 'external'
        color: '#e5a00d'
        icon: 'play'
        priority: 50
        description: 'Multimedia streaming service'

      - name: 'Office'
        sites:
          - name: 'Paperless NGX'
            url: 'https://paperless.home.dominik-schmidt.de'
            target: 'external'
            color: '#17541f'
            icon: 'leaf'
            priority: 50
            description: 'Document management system.'

          - name: 'HP OfficeJet 9022e'
            url: 'http://192.168.xxx.xxx'
            target: 'external'
            color: '#0096d6'
            icon: 'printer'
            priority: 50
            description: 'Administration panel and web scan.'

      - name: 'Administration'
        sites:
          - name: 'OpenMediaVault'
            url: 'http://192.168.xxx.xxx/'
            target: 'external'
            color: '#17541f'
            icon: 'server'
            priority: 50
            description: 'Server administration panel.'

          - name: 'FritzBox'
            url: 'https://192.168.xxx.xxx/'
            target: 'external'
            color: '#1577cf'
            icon: 'router'
            priority: 50
            description: 'Router configuration.'
```

# Considerations
Currently it requires having all links in `config.json` which is publicly accessible - I have a plan for that, but that's beyond the scope of this PR.

Currently I'm showing sites not in a group at the top of the dashboard and also in the menu - not sure about that ...
What would you expect here?
I was thinking if it was useful being able to define multiple dashboards ... Should we plan for that or just add another `dashboards` config option later on? Maybe a good idea to keep a flat config variant around anyhow.
