### PR TITLE
feat: make external site usable as default app

### DIFF
--- a/packages/web-app-external-sites/README.md
+++ b/packages/web-app-external-sites/README.md
@@ -38,45 +38,50 @@ You can also group external sites under so-called dashboards. These appear as de
 ### Example
 
 ```json
-"dashboards": [
-  {
-    "name": "My Dashboard",
-    "path": "/dashboard",
-    "color": "#ff9800",
-    "icon": "grid",
-    "sites": [
-      {
-        "name": "Plex",
-        "url": "https://plex.local",
-        "color": "#e5a00d",
-        "icon": "play",
-        "description": "Multimedia streaming service"
-      },
-      {
-        "name": "Office",
-        "sites": [
-          {
-            "name": "Paperless NGX",
-            "url": "https://paperless.local",
-            "color": "#17541f",
-            "icon": "leaf",
-            "description": "Document management system."
-          },
-          {
-            "name": "Printer Web UI",
-            "url": "http://printer.local",
-            "color": "#0096d6",
-            "icon": "printer",
-            "description": "Administration panel and web scan."
-          }
-        ]
-      }
-    ]
-  }
-]
+"config": {
+  "defaultDashboard": "My Dashboard",
+  "dashboards": [
+    {
+      "name": "My Dashboard",
+      "path": "/dashboard",
+      "color": "#ff9800",
+      "icon": "grid",
+      "sites": [
+        {
+          "name": "Plex",
+          "url": "https://plex.local",
+          "color": "#e5a00d",
+          "icon": "play",
+          "description": "Multimedia streaming service"
+        },
+        {
+          "name": "Office",
+          "sites": [
+            {
+              "name": "Paperless NGX",
+              "url": "https://paperless.local",
+              "color": "#17541f",
+              "icon": "leaf",
+              "description": "Document management system."
+            },
+            {
+              "name": "Printer Web UI",
+              "url": "http://printer.local",
+              "color": "#0096d6",
+              "icon": "printer",
+              "description": "Administration panel and web scan."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ### Dashboard Options
+
+**`dashboards`** - _(array, optional)_
 
 Each dashboard object supports the following fields:
 
@@ -87,6 +92,8 @@ Each dashboard object supports the following fields:
   - A **group**, which includes a `name` and a nested `sites` array of individual site entries.
 
 Embedded links are currently not supported. Sites not inside a group are shown above the groups without a headline.
+
+**`defaultDashboard`** _(string, optional)_ - Set the default dashboard when this application is used as default application. If not set, the first one is used.
 
 ### Optional Dashboard Attributes
 

--- a/packages/web-app-external-sites/src/index.ts
+++ b/packages/web-app-external-sites/src/index.ts
@@ -15,7 +15,8 @@ export default defineWebApplication({
 
     const appId = 'external-sites'
 
-    const { sites, dashboards } = ExternalSitesConfigSchema.parse(applicationConfig)
+    const { sites, dashboards, defaultDashboard } =
+      ExternalSitesConfigSchema.parse(applicationConfig)
 
     const routes: RouteRecordRaw[] = []
     const internalSites = sites.filter((s) => s.target === 'embedded')
@@ -49,7 +50,14 @@ export default defineWebApplication({
       })
     )
 
-    dashboards.forEach((dashboard) => {
+    dashboards.forEach((dashboard, i) => {
+      let entryPoint = false
+      if (defaultDashboard) {
+        entryPoint = defaultDashboard === dashboard.name
+      } else {
+        entryPoint = i === 0
+      }
+
       routes.push({
         path: dashboard.path || '/',
         component: h(Dashboard, { dashboard }),
@@ -57,7 +65,8 @@ export default defineWebApplication({
         meta: {
           authContext: 'user',
           title: dashboard.name,
-          patchCleanPath: true
+          patchCleanPath: true,
+          entryPoint
         }
       })
 

--- a/packages/web-app-external-sites/src/types.ts
+++ b/packages/web-app-external-sites/src/types.ts
@@ -43,6 +43,7 @@ export const ExternalSiteDashboardSchema = z.object({
 export type ExternalSiteDashboard = z.infer<typeof ExternalSiteDashboardSchema>
 
 export const ExternalSitesConfigSchema = z.object({
+  defaultDashboard: z.string().optional(),
   dashboards: z.array(ExternalSiteDashboardSchema).default([]),
   sites: z.array(ExternalSiteSchema).default([])
 })


### PR DESCRIPTION
@butonic here's your default dashboard feature ... unfortunately `external-sites` can't be configured via `options.defaultExtensionId` because it's missing in [options.go](https://github.com/opencloud-eu/opencloud/blob/62a7f79f517d397b7560dbb8c6a0141885760fe4/services/web/pkg/config/options.go)

@kulmann @JammingBen @AlexAndBear We probably introduced this config option name, when we were thinking of getting rid of the term "app". By now we settled on apps being a container for multiple extensions, right? (sort of an "extension pack")
Should this option be renamed to something like `defaultApp(lication)Id`? 
