### PR TITLE
feat: external sites visibility via user groups

### DIFF
--- a/dev/docker/csp.yaml
+++ b/dev/docker/csp.yaml
@@ -14,6 +14,7 @@ directives:
     - "'self'"
     - 'blob:'
     - 'https://embed.diagrams.net/'
+    - 'https://docs.opencloud.eu'
   img-src:
     - "'self'"
     - 'data:'

--- a/dev/docker/opencloud.apps.yaml
+++ b/dev/docker/opencloud.apps.yaml
@@ -3,6 +3,7 @@ importer:
     companionUrl: 'https://host.docker.internal:9200/companion'
 external-sites:
   config:
+    defaultDashboard: 'Main Dashboard'
     sites:
       - name: OpenCloud
         url: 'https://opencloud.eu'
@@ -10,3 +11,304 @@ external-sites:
         color: '#0D856F'
         icon: book
         priority: 50
+
+      # Public site - no visibility restrictions
+      - name: 'Public Site'
+        target: 'external'
+        url: 'https://www.google.com'
+        icon: 'earth'
+        color: '#2196F3'
+        description: 'Visible to all authenticated users'
+
+      # Admin Panel - requires admin group
+      - name: 'Admin Panel'
+        target: 'external'
+        url: 'https://github.com'
+        icon: 'settings'
+        color: '#FF0000'
+        priority: 100
+        visibility:
+          groups:
+            any: ['admin']
+
+      # Editor Tools - requires editor OR admin
+      - name: 'Editor Tools'
+        target: 'external'
+        url: 'https://code.visualstudio.com'
+        icon: 'edit'
+        color: '#FFA500'
+        priority: 90
+        visibility:
+          groups:
+            any: ['editor', 'admin']
+
+      # Super Admin Panel - requires BOTH admin AND superuser
+      - name: 'Super Admin Panel'
+        target: 'external'
+        url: 'https://aws.amazon.com/console'
+        icon: 'shield'
+        color: '#800080'
+        priority: 200
+        visibility:
+          groups:
+            all: ['admin', 'superuser']
+
+      # User Panel - requires user group but NOT guest
+      - name: 'User Panel'
+        target: 'external'
+        url: 'https://stackoverflow.com'
+        icon: 'user'
+        color: '#4CAF50'
+        visibility:
+          groups:
+            any: ['user']
+            none: ['guest']
+
+      # Dev Tools - embedded site for developers
+      - name: 'Dev Tools'
+        target: 'embedded'
+        url: 'https://developer.mozilla.org'
+        icon: 'code'
+        color: '#1e20af'
+        priority: 80
+        visibility:
+          groups:
+            any: ['developer', 'admin']
+
+      # Complex visibility Site - multiple conditions
+      - name: 'Complex Visibility Site'
+        target: 'external'
+        url: 'https://docker.com'
+        icon: 'layers'
+        color: 'warning'
+        visibility:
+          groups:
+            any: ['editor', 'admin'] # Must have editor OR admin
+            all: ['verified'] # Must also have verified
+            none: ['suspended'] # Must NOT have suspended
+
+      # HR Tools - external with HR visibility
+      - name: 'HR Management'
+        target: 'external'
+        url: 'https://docker.com'
+        icon: 'users'
+        color: '#FF0000'
+        visibility:
+          groups:
+            any: ['hr', 'admin']
+            none: ['contractor'] # HR Contractors can't see HR tools
+    dashboards:
+      # Main Dashboard - public dashboard
+      - name: 'Main Dashboard'
+        path: '/dashboard'
+        icon: 'grid'
+        color: '#b086ff'
+        sites:
+          - name: 'Documentation'
+            target: 'embedded'
+            url: 'https://docs.opencloud.eu'
+            icon: 'cloud'
+            color: '#E2BAFF'
+            priority: 90
+            visibility:
+              groups:
+                any: ['developer']
+          - name: 'Support'
+            url: 'https://support.google.com'
+            priority: 50
+            icon: 'help'
+          - name: 'Getting Started'
+            sites:
+              - name: 'Documentation'
+                url: 'https://docs.github.com'
+                icon: 'book'
+                priority: 60
+                visibility:
+                  groups:
+                    any: ['developer', 'admin']
+              - name: 'Support'
+                priority: 50
+                url: 'https://support.google.com'
+                icon: 'help'
+
+      # Admin Dashboard - only for admins
+      - name: 'Admin Dashboard'
+        path: '/admin-dashboard'
+        icon: 'shield'
+        color: '#FF0000'
+        visibility:
+          groups:
+            any: ['admin']
+        sites:
+          - name: 'System Administration'
+            sites:
+              - name: 'User Management'
+                url: 'https://admin.google.com'
+                icon: 'users'
+              - name: 'System Logs'
+                url: 'https://console.cloud.google.com'
+                icon: 'list'
+              - name: 'Server Monitoring'
+                url: 'https://grafana.com'
+                icon: 'activity'
+
+      # Finance Dashboard - embedded sites
+      - name: 'Finance Dashboard'
+        path: '/finance'
+        icon: 'currency-dollar'
+        color: 'success'
+        visibility:
+          groups:
+            any: ['finance', 'admin']
+        sites:
+          - name: 'Financial Management'
+            sites:
+              - name: 'Budget Planning'
+                url: 'https://budget.example.com'
+                icon: 'calculator'
+                visibility:
+                  groups:
+                    any: ['finance', 'admin']
+              - name: 'Financial Reports'
+                url: 'https://reports.example.com'
+                icon: 'chart'
+                visibility:
+                  groups:
+                    any: ['finance', 'admin']
+
+      # Developer Dashboard
+      - name: 'Developer Dashboard'
+        path: '/dev-dashboard'
+        icon: 'code'
+        color: '#641f45'
+        visibility:
+          groups:
+            any: ['developer', 'admin', 'viewer']
+        sites:
+          - name: 'Development Tools'
+            sites:
+              - name: 'API Documentation'
+                target: 'embedded'
+                url: 'https://docs.opencloud.eu'
+                icon: 'cloud'
+                color: '#E2BAFF'
+                visibility:
+                  groups:
+                    any: ['developer']
+              - name: 'Code Repository'
+                url: 'https://github.com'
+                icon: 'git'
+                visibility:
+                  groups:
+                    any: ['developer', 'admin']
+              - name: 'CI/CD Pipeline'
+                url: 'https://jenkins.io'
+                icon: 'play'
+                visibility:
+                  groups:
+                    any: ['admin'] # Admin only
+              - name: 'Server Monitoring'
+                url: 'https://monitoring.example.com'
+                icon: 'activity'
+                visibility:
+                  groups:
+                    any: ['admin'] # Admin only
+
+      # Support Dashboard - for support staff
+      - name: 'Support Dashboard'
+        path: '/support'
+        icon: 'help'
+        color: '#1b2864'
+        visibility:
+          groups:
+            any: ['support', 'admin']
+        sites:
+          - name: 'Customer Support'
+            sites:
+              - name: 'Ticket System'
+                url: 'https://zendesk.com'
+                icon: 'inbox'
+              - name: 'Knowledge Base'
+                url: 'https://notion.so'
+                icon: 'book'
+              - name: 'Customer Database'
+                url: 'https://salesforce.com'
+                icon: 'database'
+              - name: 'System Configuration'
+                target: 'embedded'
+                url: 'https://salesforce.com'
+                icon: 'settings'
+                visibility:
+                  groups:
+                    any: ['admin']
+              - name: 'User Management'
+                target: 'embedded'
+                url: 'https://salesforce.com'
+                icon: 'users'
+                visibility:
+                  groups:
+                    any: ['admin']
+              - name: 'Live Chat'
+                url: 'https://chat.com'
+                icon: 'message'
+                visibility:
+                  groups:
+                    any: ['support', 'admin']
+                    none: ['read-only'] # Read-only support can't use live chat
+      # Management Dashboard - complex nested visibility
+      - name: 'Management Dashboard'
+        path: '/management'
+        icon: 'briefcase'
+        color: 'warning'
+        visibility:
+          groups:
+            any: ['manager', 'hr', 'finance', 'admin']
+        sites:
+          - name: 'HR Tools'
+            sites:
+              - name: 'Employee Records'
+                target: 'embedded'
+                url: 'https://hr.example.com/employees'
+                icon: 'users'
+                visibility:
+                  groups:
+                    any: ['hr', 'admin']
+              - name: 'Payroll System'
+                target: 'embedded'
+                url: 'https://payroll.example.com'
+                icon: 'currency-dollar'
+                visibility:
+                  groups:
+                    any: ['hr', 'admin']
+          - name: 'Finance Tools'
+            sites:
+              - name: 'Budget Reports'
+                target: 'embedded'
+                url: 'https://finance.example.com/budget'
+                icon: 'chart'
+                visibility:
+                  groups:
+                    any: ['finance', 'admin']
+              - name: 'Expense Tracking'
+                target: 'embedded'
+                url: 'https://expenses.example.com'
+                icon: 'receipt'
+                visibility:
+                  groups:
+                    any: ['finance', 'admin']
+          - name: 'Management Tools'
+            sites:
+              - name: 'Team Analytics'
+                target: 'embedded'
+                url: 'https://analytics.example.com/team'
+                icon: 'trending-up'
+                visibility:
+                  groups:
+                    all: ['manager', 'verified'] # Requires BOTH
+              - name: 'Executive Reports'
+                target: 'embedded'
+                url: 'https://executive.example.com'
+                icon: 'file-text'
+                visibility:
+                  groups:
+                    any: ['executive', 'ceo'] # Only top level

--- a/packages/web-app-external-sites/README.md
+++ b/packages/web-app-external-sites/README.md
@@ -28,8 +28,10 @@ All of these 3 config options are required.
 The following attributes are optional:
 
 - **`color`** _(string)_ - specifies the Hex color codes of the icon background of the menu item.
+- **`target`** _(enum)_ - `["external"|"embedded"]` specifies the target in wich the url gets opened. Defaults to `external`. See explanation above
 - **`icon`** _(string)_ - specifies the name of a [Remix Icon](https://remixicon.com/) to be used for the menu item.
 - **`priority`** _(number)_ - specifies the order of the menu item. `50` is probably a good place to start, then go up/down based on where the item should be placed. Defaults to the highest possible number, so the item will most likely end up at the bottom of the list.
+- **`visibility`** _(object, optional)_ – "Visibility Control" for displaying sites based on user groups. See the explanation below.
 
 ## Dashboards
 
@@ -91,7 +93,8 @@ Each dashboard object supports the following fields:
   - A **site**, which includes at least `name` and `url`, or
   - A **group**, which includes a `name` and a nested `sites` array of individual site entries.
 
-Embedded links are currently not supported. Sites not inside a group are shown above the groups without a headline.
+A Site includes every field from "External Sites" above including `priority` (ordered within the group) and `target`. \
+Sites not inside a group are shown above the groups without a headline.
 
 **`defaultDashboard`** _(string, optional)_ - Set the default dashboard when this application is used as default application. If not set, the first one is used.
 
@@ -99,5 +102,208 @@ Embedded links are currently not supported. Sites not inside a group are shown a
 
 - **`color`** _(string)_ – Specifies the hex color code of the icon background for the dashboard.
 - **`icon`** _(string)_ – Specifies the name of a [Remix Icon](https://remixicon.com/) to be used for the dashboard menu item.
+- **`visibility`** _(object)_ – "Visibility Control" for displaying sites based on user groups. See the explanation below.
+
+## Visibility
+
+> [!IMPORTANT]  
+> We're loading the complete site configuration, including visibility-controlled sites, within config.json.
+> The purpose of this feature isn't security, but rather to offer a more user-friendly way of presenting certain
+> menu entries, preventing potential confusion for particular user segments.
+> _**Please be aware that sensitive URLs should not be hidden using this method, as they are still retrievable from the config.json file.**_
+
+Visibility offers a way of hiding certain Menu/Dashboard sites via user groups.
+
+### Example
+
+```json
+  "config": {
+    "sites": [
+      {
+        "name": "OpenCloud",
+        "url": "https://opencloud.eu",
+        "target": "external",
+        "color": "#0D856F",
+        "icon": "book",
+        "priority": 50
+      },
+      {
+        "name": "Only Visible to users with admin group",
+        "url": "https://opencloud.eu",
+        "target": "external",
+        "color": "#0D856F",
+        "icon": "book",
+        "priority": 50,
+        "visibility":
+        {
+          "groups":{
+            "any": [ "admin" ]
+          }
+        }
+      }
+    ],
+    "defaultDashboard": "My Dashboard",
+    "dashboards": [
+      {
+        "name": "My Dashboard",
+        "path": "/dashboard",
+        "color": "#ff9800",
+        "icon": "grid",
+        "sites": [
+          {
+            "name": "Plex",
+            "url": "https://plex.local",
+            "color": "#e5a00d",
+            "icon": "play",
+            "description": "Multimedia streaming service",
+            "visibility":
+            {
+              "groups":
+              {
+                "any": [ "editor", "admin" ],
+                "all": [ "verified" ],
+                "none": [ "suspended" ]
+              }
+            }
+          },
+          {
+            "name": "Documentation",
+            "url": "https://docs.opencloud.eu",
+            "color": "#E2BAFF",
+            "target": "embedded",
+            "icon": "cloud",
+            "description": "OpenCloud Documentation"
+          },
+          {
+            "name": "Office",
+            "sites": [
+              {
+                "name": "Paperless NGX",
+                "url": "https://paperless.local",
+                "color": "#17541f",
+                "icon": "leaf",
+                "priority": 50,
+                "description": "Document management system."
+              },
+              {
+                "name": "Printer Web UI",
+                "url": "http://printer.local",
+                "color": "#0096d6",
+                "icon": "printer",
+                "priority": 40,
+                "description": "Administration panel and web scan."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+```
+
+<details><summary>Via apps.yaml file</summary>
+
+```yaml
+external-sites:
+  config:
+    sites:
+      - name: OpenCloud
+        url: https://opencloud.eu
+        target: external
+        color: '#0D856F'
+        icon: book
+        priority: 50
+      - name: Only Visible to users with admin group
+        url: https://opencloud.eu
+        target: external
+        color: '#0D856F'
+        icon: book
+        priority: 50
+        visibility:
+          groups:
+            any:
+              - admin
+    defaultDashboard: My Dashboard
+    dashboards:
+      - name: My Dashboard
+        path: /dashboard
+        color: '#ff9800'
+        icon: grid
+        sites:
+          - name: Plex
+            url: https://plex.local
+            color: '#e5a00d'
+            icon: play
+            description: Multimedia streaming service
+            visibility:
+              groups:
+                any:
+                  - editor
+                  - admin
+                all:
+                  - verified
+                none:
+                  - suspended
+          - name: Documentation
+            url: https://docs.opencloud.eu
+            color: '#E2BAFF'
+            target: embedded
+            icon: cloud
+            description: OpenCloud Documentation
+          - name: Office
+            sites:
+              - name: Paperless NGX
+                url: https://paperless.local
+                color: '#17541f'
+                icon: leaf
+                priority: 50
+                description: Document management system.
+              - name: Printer Web UI
+                url: http://printer.local
+                color: '#0096d6'
+                icon: printer
+                priority: 40
+                description: Administration panel and web scan.
+```
+
+</details>
+
+For more example see [../../dev/docker/opencloud.apps.yaml](../../dev/docker/opencloud.apps.yaml)
+
+### Visibility Options
+
+`visibility` (object, optional)
+
+Each visibility object must have a `groups` field within the groups you can have one or all options `any`,`all`,`none`
+
+`groups` (object, required)
+
+- `any` (array, at least one is required)
+- `all` (array, at least one is required)
+- `none` (array, at least one is required)
+
+```json
+"visibility":
+    {
+      "groups":
+      {
+        "any": [ "editor", "admin" ],
+        "all": [ "verified" ],
+        "none": [ "suspended" ]
+      }
+    }
+```
+
+<details><summary>Yaml Example file</summary>
+
+```yaml
+visibility:
+  groups:
+    any: ['editor', 'admin'] # Must have editor OR admin
+    all: ['verified'] # Must also have verified
+    none: ['suspended'] # Must NOT have suspended
+```
+
+</details>
 
 Please refer to [the Web app docs](https://docs.opencloud.eu/docs/admin/configuration/web-applications) if you want to learn how to configure a Web app.

--- a/packages/web-app-external-sites/src/ExternalSitesDashboard.vue
+++ b/packages/web-app-external-sites/src/ExternalSitesDashboard.vue
@@ -2,10 +2,11 @@
   <main id="external-sites-dashboard" class="oc-pt-m oc-pb-l oc-flex oc-flex-center">
     <div class="page">
       <h1 class="title oc-mb-m" v-text="dashboard.name" />
-      <dashboard-group :group="standaloneGroup" />
+      <div v-if="standaloneGroup.sites.length === 0 && groups.length === 0">No sites available</div>
+      <dashboard-group :group="standaloneGroup" :dashboard-path="dashboard.path" />
 
       <template v-for="group in groups" :key="group.name">
-        <dashboard-group :group="group" />
+        <dashboard-group :group="group" :dashboard-path="dashboard.path" />
       </template>
     </div>
   </main>
@@ -14,25 +15,32 @@
 <script setup lang="ts">
 import DashboardGroup from './components/DashboardGroup.vue'
 import { computed } from 'vue'
+import { filterVisibleSites } from './untils'
 import {
   ExternalSiteGroup,
   ExternalSite,
   isExternalSiteGroup,
-  ExternalSiteDashboard
+  ExternalSiteDashboard,
+  ExternalSiteOrSiteGroup
 } from './types'
 
 const props = defineProps<{
   dashboard: ExternalSiteDashboard
 }>()
 
+// Apply filtering to the dashboard sites
+const filteredSites = computed((): ExternalSiteOrSiteGroup[] => {
+  return filterVisibleSites(props.dashboard.sites || [])
+})
+
 const standaloneGroup = computed((): ExternalSiteGroup => {
   return {
-    sites: props.dashboard.sites.filter((item) => !isExternalSiteGroup(item)) as ExternalSite[]
+    sites: filteredSites.value.filter((item) => !isExternalSiteGroup(item)) as ExternalSite[]
   }
 })
 
 const groups = computed((): ExternalSiteGroup[] => {
-  return props.dashboard.sites.filter((item) => isExternalSiteGroup(item))
+  return filteredSites.value.filter((item) => isExternalSiteGroup(item)) as ExternalSiteGroup[]
 })
 </script>
 

--- a/packages/web-app-external-sites/src/components/DashboardGroup.vue
+++ b/packages/web-app-external-sites/src/components/DashboardGroup.vue
@@ -4,18 +4,30 @@
   </h2>
   <div class="link-list oc-mb-m">
     <oc-list class="links">
-      <dashboard-link v-for="site in group.sites" :key="site.name" :site="site" />
+      <dashboard-link
+        v-for="site in sortedSites"
+        :key="site.name"
+        :site="site"
+        :dashboard-path="dashboardPath"
+      />
     </oc-list>
   </div>
 </template>
 
 <script setup lang="ts">
 import DashboardLink from './DashboardLink.vue'
-import { ExternalSiteGroup } from '../types'
+import { ExternalSiteGroup, ExternalSite } from '../types'
+import { computed } from 'vue'
 
-defineProps<{
+const props = defineProps<{
   group: ExternalSiteGroup
+  dashboardPath: string
 }>()
+
+const sortedSites = computed((): ExternalSite[] => {
+  const sortedSites = [...props.group.sites]
+  return sortedSites.sort((a, b) => a.priority - b.priority) as ExternalSite[]
+})
 </script>
 
 <style lang="scss" scoped>

--- a/packages/web-app-external-sites/src/components/DashboardLink.vue
+++ b/packages/web-app-external-sites/src/components/DashboardLink.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="tile oc-card oc-card-default oc-card-rounded">
-    <a :href="site.url" target="_blank">
+    <a v-if="site.target === 'external'" :href="site.url" target="_blank">
       <div class="tile-body oc-card-body oc-p">
         <div class="tile-content oc-flex oc-flex-middle">
           <div class="tile-icon">
@@ -15,15 +15,42 @@
         </div>
       </div>
     </a>
+    <router-link
+      v-if="site.target === 'embedded'"
+      :to="getNestedSiteRoutePath(site)"
+      class="site-link"
+    >
+      <div class="tile-body oc-card-body oc-p">
+        <div class="tile-content oc-flex oc-flex-middle">
+          <div class="tile-icon">
+            <oc-icon v-if="site.icon" :name="site.icon" :color="site.color" size="xlarge" />
+          </div>
+          <div>
+            <h3 class="oc-my-s oc-text-truncate mark-element tile-title">
+              {{ site.name }}
+            </h3>
+            <p class="oc-my-s mark-element">{{ site.description }}</p>
+          </div>
+        </div>
+      </div>
+    </router-link>
   </li>
 </template>
 
 <script setup lang="ts">
 import { ExternalSite } from '../types'
+import { makeSlug } from '../untils'
 
-defineProps<{
+const props = defineProps<{
   site: ExternalSite
+  dashboardPath: string
 }>()
+
+const getNestedSiteRoutePath = (site: ExternalSite): string => {
+  const sitePath = makeSlug(site.name)
+
+  return `/external-sites${props.dashboardPath}/${sitePath}`
+}
 </script>
 
 <style lang="scss" scoped>

--- a/packages/web-app-external-sites/src/index.ts
+++ b/packages/web-app-external-sites/src/index.ts
@@ -4,7 +4,14 @@ import translations from '../l10n/translations.json'
 import { useGettext } from 'vue3-gettext'
 import { computed, h } from 'vue'
 import { RouteRecordRaw } from 'vue-router'
-import { ExternalSitesConfigSchema } from './types'
+import { ExternalSitesConfigSchema, ExternalSite } from './types'
+import {
+  shouldDisplay,
+  filterVisibleSites,
+  createVisibilityGuard,
+  makeSlug,
+  flattenSites
+} from './untils'
 
 import App from './App.vue'
 import Dashboard from './ExternalSitesDashboard.vue'
@@ -19,37 +26,24 @@ export default defineWebApplication({
       ExternalSitesConfigSchema.parse(applicationConfig)
 
     const routes: RouteRecordRaw[] = []
+
+    // Add site routes (only embedded sites get routes)
     const internalSites = sites.filter((s) => s.target === 'embedded')
-    internalSites.forEach(({ name, url }) => {
+    internalSites.forEach(({ name, url, visibility }) => {
       routes.push({
-        path: urlJoin(encodeURIComponent(name).toLowerCase()),
+        path: urlJoin(encodeURIComponent(makeSlug(name))),
         component: h(App, { name, url }),
         name: `${appId}-${name}`,
         meta: {
           authContext: 'user',
           title: name,
           patchCleanPath: true
-        }
+        },
+        ...(visibility && { beforeEnter: createVisibilityGuard(visibility) })
       })
     })
 
-    const menuItems = computed<AppMenuItemExtension[]>(() =>
-      sites.map((s) => {
-        return {
-          id: `${appId}-${s.name}`,
-          type: 'appMenuItem',
-          label: () => $gettext(s.name),
-          color: s.color,
-          icon: s.icon,
-          priority: s.priority,
-          ...(s.target === 'embedded' && {
-            path: urlJoin(appId, encodeURIComponent(s.name).toLowerCase())
-          }),
-          ...(s.target === 'external' && { url: s.url })
-        }
-      })
-    )
-
+    // Add dashboard routes
     dashboards.forEach((dashboard, i) => {
       let entryPoint = false
       if (defaultDashboard) {
@@ -58,8 +52,10 @@ export default defineWebApplication({
         entryPoint = i === 0
       }
 
+      const dashboardPath = dashboard.path || '/'
+
       routes.push({
-        path: dashboard.path || '/',
+        path: dashboardPath,
         component: h(Dashboard, { dashboard }),
         name: `${appId}-dashboard-${dashboard.name}`,
         meta: {
@@ -67,17 +63,74 @@ export default defineWebApplication({
           title: dashboard.name,
           patchCleanPath: true,
           entryPoint
-        }
+        },
+        ...(dashboard.visibility && { beforeEnter: createVisibilityGuard(dashboard.visibility) })
       })
 
-      menuItems.value.push({
+      // Create nested routes for embedded dashboard sites
+      const allDashboardSites: ExternalSite[] = flattenSites(dashboard.sites)
+
+      // Create nested routes for embedded sites
+      allDashboardSites
+        .filter((site) => site.target === 'embedded')
+        .forEach((site) => {
+          const sitePath = makeSlug(site.name)
+
+          // Always create: /external-sites/dashboard-path/site-name
+          const nestedPath = urlJoin(dashboardPath, sitePath)
+          routes.push({
+            path: nestedPath,
+            component: h(App, { name: site.name, url: site.url }),
+            name: `${appId}-dashboard-${dashboardPath}-${sitePath}`,
+            meta: {
+              authContext: 'user',
+              title: site.name,
+              patchCleanPath: true
+            },
+            ...(site.visibility && { beforeEnter: createVisibilityGuard(site.visibility) })
+          })
+        })
+    })
+
+    // Computed for menu items
+    const menuItems = computed<AppMenuItemExtension[]>(() => {
+      // Filter top-level sites
+      const actualSites = sites.filter((s) => shouldDisplay(s.visibility))
+
+      // Filter dashboards and their nested sites
+      const actualDashboards = dashboards.filter((d) => {
+        // First check if user can see the dashboard itself
+        if (!shouldDisplay(d.visibility)) return false
+
+        // Then check if the dashboard has any visible sites
+        const filteredSites = filterVisibleSites(d.sites)
+
+        return filteredSites.length > 0
+      })
+
+      const siteMenuItems = actualSites.map((s) => ({
+        id: `${appId}-${s.name}`,
+        type: 'appMenuItem' as const,
+        label: () => $gettext(s.name),
+        color: s.color,
+        icon: s.icon,
+        priority: s.priority,
+        ...(s.target === 'embedded' && {
+          path: urlJoin(appId, encodeURIComponent(makeSlug(s.name)))
+        }),
+        ...(s.target === 'external' && { url: s.url })
+      }))
+
+      const dashboardMenuItems = actualDashboards.map((dashboard) => ({
         id: `${appId}-dashboard-${dashboard.name}`,
-        type: 'appMenuItem',
+        type: 'appMenuItem' as const,
         label: () => dashboard.name,
         icon: dashboard.icon || 'grid',
         path: urlJoin(...[appId, dashboard.path].filter(Boolean)),
         ...(dashboard.color && { color: dashboard.color })
-      })
+      }))
+
+      return [...siteMenuItems, ...dashboardMenuItems]
     })
 
     return {

--- a/packages/web-app-external-sites/src/types.ts
+++ b/packages/web-app-external-sites/src/types.ts
@@ -1,13 +1,28 @@
 import { z } from 'zod'
 
+export const VisibilityControlSchema = z
+  .object({
+    groups: z
+      .object({
+        any: z.array(z.string()).optional(),
+        all: z.array(z.string()).optional(),
+        none: z.array(z.string()).optional()
+      })
+      .optional()
+  })
+  .optional()
+
+export type VisibilityControl = z.infer<typeof VisibilityControlSchema>
+
 export const ExternalSiteSchema = z.object({
   name: z.string(),
-  target: z.enum(['embedded', 'external']),
+  target: z.enum(['embedded', 'external']).optional().default('external'),
   url: z.string(),
   color: z.string().optional(),
   icon: z.string().optional(),
   priority: z.number().optional(),
-  description: z.string().optional()
+  description: z.string().optional(),
+  visibility: VisibilityControlSchema.optional()
 })
 
 export type ExternalSite = z.infer<typeof ExternalSiteSchema>
@@ -37,7 +52,8 @@ export const ExternalSiteDashboardSchema = z.object({
   name: z.string(),
   icon: z.string().optional(),
   color: z.string().optional(),
-  sites: z.array(ExternalSiteOrSiteGroupSchema)
+  sites: z.array(ExternalSiteOrSiteGroupSchema),
+  visibility: VisibilityControlSchema.optional()
 })
 
 export type ExternalSiteDashboard = z.infer<typeof ExternalSiteDashboardSchema>

--- a/packages/web-app-external-sites/src/untils.ts
+++ b/packages/web-app-external-sites/src/untils.ts
@@ -1,0 +1,99 @@
+import { useUserStore } from '@opencloud-eu/web-pkg'
+import {
+  VisibilityControl,
+  ExternalSiteOrSiteGroup,
+  isExternalSiteGroup,
+  isExternalSite,
+  ExternalSite
+} from './types'
+import { NavigationGuardNext, RouteLocationNormalized } from 'vue-router'
+
+// Helper function to check visibility requirements
+export const shouldDisplay = (visibilityConfig?: VisibilityControl): boolean => {
+  const userStore = useUserStore()
+
+  if (!visibilityConfig?.groups) return true
+  if (!userStore.user?.memberOf) return false
+
+  const userGroups = userStore.user.memberOf.map((g) => g.displayName)
+  const { any, all, none } = visibilityConfig.groups
+
+  // Check if the user has none of the forbidden groups
+  if (none && none.some((group) => userGroups.includes(group))) {
+    return false
+  }
+
+  // Check if a user has all required groups
+  if (all && !all.every((group) => userGroups.includes(group))) {
+    return false
+  }
+
+  // Check if a user has any of the allowed groups
+  return !(any && !any.some((group) => userGroups.includes(group)))
+}
+
+// Recursive function to filter sites and site groups based on visibility
+export const filterVisibleSites = (
+  sitesOrGroups: ExternalSiteOrSiteGroup[]
+): ExternalSiteOrSiteGroup[] => {
+  if (!sitesOrGroups || !Array.isArray(sitesOrGroups)) {
+    return []
+  }
+
+  return sitesOrGroups.reduce<ExternalSiteOrSiteGroup[]>((acc, item) => {
+    if (isExternalSiteGroup(item)) {
+      // It's a site group - filter its nested sites
+      const filteredSites = filterVisibleSites(item.sites) as ExternalSite[]
+      if (filteredSites.length > 0) {
+        // Only include the group if it has visible sites
+        acc.push({
+          ...item,
+          sites: filteredSites
+        })
+      }
+    } else {
+      const siteItem = item as ExternalSite
+      // It's a site - check its visibility
+      if (shouldDisplay(siteItem.visibility)) {
+        acc.push(item)
+      }
+    }
+    return acc
+  }, [])
+}
+
+// Route guard for visibility-based checking
+export const createVisibilityGuard = (visibilityConfig?: VisibilityControl) => {
+  return (
+    to: RouteLocationNormalized,
+    from: RouteLocationNormalized,
+    next: NavigationGuardNext
+  ) => {
+    if (shouldDisplay(visibilityConfig)) {
+      next()
+    } else {
+      next('/')
+    }
+  }
+}
+
+// Flatten Dashboard Sites
+export const flattenSites = (sitesOrGroups: ExternalSiteOrSiteGroup[]) => {
+  let flattened: ExternalSite[] = []
+  sitesOrGroups.forEach((item) => {
+    if (isExternalSite(item)) {
+      flattened.push(item)
+    } else {
+      flattened = flattened.concat(flattenSites(item.sites))
+    }
+  })
+
+  return flattened
+}
+
+export const makeSlug = (name: string): string => {
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+}

--- a/packages/web-app-external-sites/tests/e2e/openExternalSite.spec.ts
+++ b/packages/web-app-external-sites/tests/e2e/openExternalSite.spec.ts
@@ -1,26 +1,391 @@
-import { test, Page, expect } from '@playwright/test'
+import { test, Page, expect, Browser } from '@playwright/test'
 import { AppSwitcher } from '../../../../support/pages/appSwitcher'
-import { loginAsUser, logout } from '../../../../support/helpers/authHelper'
-import { createRandomUser } from '../../../../support/helpers/api/apiHelper'
+import {
+  loginAsUser,
+  logout,
+  logoutWithoutCloseContext
+} from '../../../../support/helpers/authHelper'
+import { createRandomUser, createUserWithGroups } from '../../../../support/helpers/api/apiHelper'
 
 let userPage: Page
+let browser: Browser
 
-test.beforeEach(async ({ browser }) => {
-  const user = await createRandomUser()
-  userPage = (await loginAsUser(browser, user.username, user.password)).page
-})
+test.describe('External Sites Visibility Control', () => {
+  test.beforeEach(({ browser: testBrowser }) => {
+    browser = testBrowser
+  })
 
-test.afterEach(async () => {
-  await logout(userPage)
-})
+  test.afterEach(async () => {
+    if (userPage) {
+      await logout(userPage)
+    }
+  })
 
-test('open external site', async () => {
-  const appSwitcher = new AppSwitcher(userPage)
-  await appSwitcher.clickAppSwitcher()
+  test('user with correct groups can see external sites in menu', async () => {
+    const user = await createUserWithGroups(['admin', 'editor'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
 
-  const [newPage] = await Promise.all([
-    userPage.waitForEvent('popup'),
-    appSwitcher.openExternalSite('OpenCloud')
-  ])
-  await expect(newPage).toHaveURL(/https:\/\/opencloud\.eu/)
+    const appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    // Check visibility
+    await expect(appSwitcher.getExternalSite('Admin Panel')).toBeVisible()
+    await expect(appSwitcher.getExternalSite('Editor Tools')).toBeVisible()
+    await expect(appSwitcher.getExternalSite('Public Site')).toBeVisible()
+
+    // Check link attributes
+    await expect(appSwitcher.getExternalSite('Admin Panel')).toHaveAttribute(
+      'href',
+      'https://github.com'
+    )
+    await expect(appSwitcher.getExternalSite('Admin Panel')).toHaveAttribute('target', '_blank')
+  })
+
+  test('user without required groups cannot see restricted external sites', async () => {
+    const user = await createUserWithGroups(['viewer'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    const appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    // Should not see restricted sites
+    await expect(appSwitcher.getExternalSite('Admin Panel')).not.toBeVisible()
+    await expect(appSwitcher.getExternalSite('Editor Tools')).not.toBeVisible()
+
+    // But should see public sites
+    await expect(appSwitcher.getExternalSite('Public Site')).toBeVisible()
+  })
+
+  test('user cannot directly visit embedded site route without the required group', async () => {
+    const user = await createUserWithGroups(['viewer'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    // Try to navigate directly to embedded site route
+    await userPage.goto('/external-sites/dev-tools')
+
+    // Should be redirected to /
+    await expect(userPage).toHaveURL(/files|^\/$/)
+  })
+
+  test('user with developer visibility can see embedded site and see routes', async () => {
+    const user = await createUserWithGroups(['developer'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    const appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    // Should see embedded site in menu
+    await expect(appSwitcher.getExternalSite('Dev Tools')).toBeVisible()
+
+    // Should NOT have target="_blank" (it's embedded)
+    await expect(appSwitcher.getExternalSite('Dev Tools')).not.toHaveAttribute('target', '_blank')
+
+    // Should be able to navigate to embedded route
+    await appSwitcher.getExternalSite('Dev Tools').click()
+    await expect(userPage).toHaveURL(/external-sites\/dev-tools/)
+  })
+
+  test('dashboard visibility control works correctly', async () => {
+    const user = await createUserWithGroups(['admin'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    const appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    // Should see admin dashboard
+    await expect(appSwitcher.getDashboard('Admin Dashboard')).toBeVisible()
+    // Should be able to navigate to dashboard
+    await appSwitcher.openDashboard('Admin Dashboard')
+
+    await expect(userPage).toHaveURL(/external-sites\/admin-dashboard/)
+    await expect(userPage.locator('h1:has-text("Admin Dashboard")')).toBeVisible()
+  })
+
+  test('restricted dashboard is not visible to unauthorized users', async () => {
+    const user = await createUserWithGroups(['viewer'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    const appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    // Should NOT see admin dashboard
+    await expect(appSwitcher.getDashboard('Admin Dashboard')).not.toBeVisible()
+
+    // Should see public dashboard
+    await expect(appSwitcher.getDashboard('Main Dashboard')).toBeVisible()
+  })
+
+  test('restricted dashboard route cannot be accessed directly', async () => {
+    const user = await createUserWithGroups(['viewer'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    // Try to access admin dashboard directly
+    await userPage.goto('/external-sites/admin-dashboard')
+
+    // Should be redirected
+    await expect(userPage).toHaveURL(/files|^\/$/)
+  })
+
+  test('dashboard shows external links with correct attributes', async () => {
+    const user = await createUserWithGroups(['support'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    // Navigate to support dashboard
+    await userPage.goto('/external-sites/support')
+    await userPage.pause()
+
+    // All dashboard sites should be external links
+    await expect(userPage.getByRole('link', { name: 'Ticket System' })).toHaveAttribute(
+      'href',
+      'https://zendesk.com'
+    )
+    await expect(userPage.getByRole('link', { name: 'Ticket System' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
+
+    await expect(userPage.getByRole('link', { name: 'Knowledge Base' })).toHaveAttribute(
+      'href',
+      'https://notion.so'
+    )
+    await expect(userPage.getByRole('link', { name: 'Knowledge Base' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
+  })
+
+  test('visibility control with "all" groups requirement works', async () => {
+    // User with only one of the required groups - should not see teh site
+    const user1 = await createUserWithGroups(['admin'])
+    userPage = (await loginAsUser(browser, user1.username, user1.password)).page
+
+    let appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    await expect(appSwitcher.getExternalSite('Super Admin Panel')).not.toBeVisible()
+    await logoutWithoutCloseContext(userPage)
+
+    // User with all required groups - should see the site
+    const user2 = await createUserWithGroups(['admin', 'superuser'])
+    userPage = (await loginAsUser(browser, user2.username, user2.password)).page
+
+    appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    await expect(appSwitcher.getExternalSite('Super Admin Panel')).toBeVisible()
+    await expect(appSwitcher.getExternalSite('Super Admin Panel')).toHaveAttribute(
+      'href',
+      'https://aws.amazon.com/console'
+    )
+  })
+
+  test('visibility control with "none" groups restriction works', async () => {
+    // User with forbidden group - should not see even with allowed group
+    const user = await createUserWithGroups(['user', 'guest'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    const appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    await expect(appSwitcher.getExternalSite('User Panel')).not.toBeVisible()
+  })
+
+  test('complex visibility control with multiple conditions works', async () => {
+    // User meets all conditions
+    const validUser = await createUserWithGroups(['editor', 'verified'])
+    userPage = (await loginAsUser(browser, validUser.username, validUser.password)).page
+
+    let appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    await expect(appSwitcher.getExternalSite('Complex Visibility Site')).toBeVisible()
+    await expect(appSwitcher.getExternalSite('Complex Visibility Site')).toHaveAttribute(
+      'href',
+      'https://docker.com'
+    )
+    await logout(userPage)
+
+    // User fails "all" condition
+    const invalidUser = await createUserWithGroups(['editor']) // missing 'verified'
+    userPage = (await loginAsUser(browser, invalidUser.username, invalidUser.password)).page
+
+    appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    await expect(appSwitcher.getExternalSite('Complex Visibility Site')).not.toBeVisible()
+  })
+
+  test('user with no groups can see public sites', async () => {
+    const user = await createRandomUser() // No specific groups
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    const appSwitcher = new AppSwitcher(userPage)
+    await appSwitcher.clickAppSwitcher()
+
+    // Should see public sites (no visibility config)
+    await expect(appSwitcher.getExternalSite('Public Site')).toBeVisible()
+    await expect(appSwitcher.getExternalSite('OpenCloud')).toBeVisible()
+
+    // Should not see restricted sites
+    await expect(appSwitcher.getExternalSite('Admin Panel')).not.toBeVisible()
+    await expect(appSwitcher.getExternalSite('Editor Tools')).not.toBeVisible()
+  })
+
+  //---
+  test('dashboard shows only visible sites within site groups', async () => {
+    const user = await createUserWithGroups(['support'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    // Navigate to support dashboard
+    await userPage.goto('/external-sites/support')
+
+    // Should see sites available to support users
+    await expect(userPage.getByRole('link', { name: 'Ticket System' })).toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'Knowledge Base' })).toBeVisible()
+
+    // Should NOT see admin-only sites
+    await expect(userPage.getByRole('link', { name: 'System Configuration' })).not.toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'User Management' })).not.toBeVisible()
+  })
+
+  test('dashboard hides entire site groups when no sites are visible', async () => {
+    const user = await createUserWithGroups(['viewer'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    // Navigate to developer dashboard that viewer should see but with no visible sites
+    await userPage.goto('/external-sites/dev-dashboard')
+
+    // Should show "no sites available" message
+    await expect(userPage.locator('text=No sites available')).toBeVisible()
+
+    // Should NOT show any site group headings
+    await expect(userPage.locator('h2:has-text("Development Tools")')).not.toBeVisible()
+    await expect(userPage.locator('h2:has-text("Admin Tools")')).not.toBeVisible()
+  })
+
+  test('mixed visibility site groups show only permitted sites', async () => {
+    const user = await createUserWithGroups(['developer'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    await userPage.goto('/external-sites/dev-dashboard')
+
+    // Should see the site group heading
+    await expect(userPage.locator('h2:has-text("Development Tools")')).toBeVisible()
+
+    // Should see developer-visible sites
+    await expect(userPage.getByRole('link', { name: 'API Documentation' })).toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'Code Repository' })).toBeVisible()
+
+    // Should NOT see admin-only sites in the same group
+    await expect(userPage.getByRole('link', { name: 'CI/CD Pipeline' })).not.toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'Server Monitoring' })).not.toBeVisible()
+  })
+
+  test('user with elevated permissions sees all sites in mixed groups', async () => {
+    const user = await createUserWithGroups(['developer', 'admin'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    await userPage.goto('/external-sites/dev-dashboard')
+
+    // Should see all sites in the group
+    await expect(userPage.getByRole('link', { name: 'API Documentation' })).toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'Code Repository' })).toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'CI/CD Pipeline' })).toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'Server Monitoring' })).toBeVisible()
+  })
+
+  test('nested visibility control works for embedded sites in dashboards', async () => {
+    const user = await createUserWithGroups(['finance'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    await userPage.goto('/external-sites/finance')
+
+    // Should see embedded finance sites
+    const budgetLink = userPage.getByRole('link', { name: 'Budget Planning' })
+    await expect(budgetLink).toBeVisible()
+  })
+
+  test('site group with no visible sites is completely hidden', async () => {
+    const user = await createUserWithGroups(['viewer'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    await userPage.goto('/external-sites/admin-dashboard')
+    // Should be redirected due to not visible
+    await expect(userPage).toHaveURL(/files|^\/$/)
+  })
+
+  test('dashboard with partial site visibility shows filtered groups', async () => {
+    const user = await createUserWithGroups(['hr'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    await userPage.goto('/external-sites/management')
+
+    // Should see HR section
+    await expect(userPage.locator('h2:has-text("HR Tools")')).toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'Employee Records' })).toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'Payroll System' })).toBeVisible()
+
+    // Should NOT see Finance section (no finance group)
+    await expect(userPage.locator('h2:has-text("Finance Tools")')).not.toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'Budget Reports' })).not.toBeVisible()
+  })
+
+  test('complex nested visibility control with multiple group requirements', async () => {
+    const user = await createUserWithGroups(['manager', 'verified'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    await userPage.goto('/external-sites/management')
+
+    // Should see manager tools that require both manager AND verified
+    await expect(userPage.locator('h2:has-text("Management Tools")')).toBeVisible()
+    await expect(userPage.getByRole('link', { name: 'Team Analytics' })).toBeVisible()
+
+    // But should NOT see executive tools (requires executive group)
+    await expect(userPage.getByRole('link', { name: 'Executive Reports' })).not.toBeVisible()
+  })
+
+  //--
+  test('dashboard sites respect target attribute for external links', async () => {
+    const user = await createUserWithGroups(['support'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    await userPage.goto('/external-sites/support')
+
+    // External sites should have target="_blank"
+    await expect(userPage.getByRole('link', { name: 'Ticket System' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
+    await expect(userPage.getByRole('link', { name: 'Knowledge Base' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
+  })
+
+  test('dashboard sites respect target attribute for embedded links', async () => {
+    const user = await createUserWithGroups(['support', 'admin'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    await userPage.goto('/external-sites/support')
+
+    // Embedded sites should NOT have target="_blank"
+    const internalChatLink = userPage.getByRole('link', { name: 'User Management' })
+    await expect(internalChatLink).not.toHaveAttribute('target', '_blank')
+
+    // Should navigate within the app
+    await internalChatLink.click()
+    await expect(userPage).toHaveURL(/external-sites\/support\/user-management/)
+  })
+
+  test('embedded dashboard sites can be accessed directly with proper groups', async () => {
+    const user = await createUserWithGroups(['developer'])
+    userPage = (await loginAsUser(browser, user.username, user.password)).page
+
+    // Should be able to access embedded dashboard site directly
+    await userPage.goto('/external-sites/dev-dashboard/api-documentation')
+    await expect(userPage).toHaveURL(/external-sites\/dev-dashboard\/api-documentation/)
+
+    // Should show embedded content
+    await expect(userPage.locator('iframe')).toBeVisible()
+  })
 })

--- a/support/helpers/api/apiHelper.ts
+++ b/support/helpers/api/apiHelper.ts
@@ -3,7 +3,8 @@ import { getAdminToken } from './getToken'
 import config from '../../../playwright.config'
 import { v4 as uuidv4 } from 'uuid'
 
-const API_URL = config.use.baseURL + '/graph/v1.0/users'
+const API_USERS_URL = config.use.baseURL + '/graph/v1.0/users'
+const API_GROUPS_URL = config.use.baseURL + '/graph/v1.0/groups'
 const adminUsername = process.env.ADMIN_USERNAME ?? 'admin'
 const adminPassword = process.env.ADMIN_PASSWORD ?? 'admin'
 
@@ -11,7 +12,7 @@ export async function createUser(username: string, password: string) {
   const adminToken = await getAdminToken(adminUsername, adminPassword)
 
   const context = await request.newContext()
-  const response = await context.post(API_URL, {
+  const response = await context.post(API_USERS_URL, {
     headers: {
       Authorization: `Bearer ${adminToken}`,
       'Content-Type': 'application/json'
@@ -35,6 +36,82 @@ export async function createUser(username: string, password: string) {
 }
 
 export async function createRandomUser() {
-  const uniquePrefix = uuidv4().substring(0, 4)
+  const uniquePrefix = uuidv4().substring(0, 8)
   return await createUser(`Alice-${uniquePrefix}`, '123')
+}
+
+async function createGroup(group: string) {
+  const adminToken = await getAdminToken(adminUsername, adminPassword)
+
+  const context = await request.newContext()
+  const response = await context.post(API_GROUPS_URL, {
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      'Content-Type': 'application/json'
+    },
+    data: {
+      displayName: group
+    }
+  })
+
+  if (response.status() === 409) {
+    const response = await context.get(`${API_GROUPS_URL}?$search="${group}"`, {
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        'Content-Type': 'application/json'
+      }
+    })
+
+    const data = await response.json()
+    return { id: data.value[0]?.id, displayName: data.value[0]?.displayName }
+  } else if (!response.ok()) {
+    throw new Error(
+      `Failed to create group ${group}: ${response.status()} - ${await response.text()}`
+    )
+  }
+
+  const data = await response.json()
+  return { id: data.id, displayName: data.displayName }
+}
+
+async function addUserToGroup(groupId: string, userId: string) {
+  const adminToken = await getAdminToken(adminUsername, adminPassword)
+  const context = await request.newContext()
+  const response = await context.post(`${API_GROUPS_URL}/${groupId}/members/$ref`, {
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      'Content-Type': 'application/json'
+    },
+    data: {
+      '@odata.id': `${API_USERS_URL}/${userId}`
+    }
+  })
+
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to add user ${userId} to group ${groupId}: ${response.status()} - ${await response.text()}`
+    )
+  }
+}
+
+export async function createUserWithGroups(groups: string[], username?: string, password?: string) {
+  const user =
+    username && password ? await createUser(username, password) : await createRandomUser()
+
+  groups.forEach(async (group) => {
+    const newGroup = await createGroup(group)
+    addUserToGroup(newGroup.id, user.id)
+  })
+
+  return user
+}
+
+export async function updateUserGroups(userId: string, newGroups: string[]) {
+  // Remove user from all current groups
+  // await removeUserFromAllGroups(userId)
+
+  newGroups.forEach(async (group) => {
+    const newGroup = await createGroup(group)
+    addUserToGroup(newGroup.id, userId)
+  })
 }

--- a/support/helpers/authHelper.ts
+++ b/support/helpers/authHelper.ts
@@ -21,6 +21,12 @@ export async function loginAsUser(
   return { page }
 }
 
+export async function logoutWithoutCloseContext(page: Page): Promise<void> {
+  const context = page.context()
+  const loginPage = new LoginPage(page)
+  await loginPage.logout()
+}
+
 export async function logout(page: Page): Promise<void> {
   const context = page.context()
   const loginPage = new LoginPage(page)

--- a/support/pages/appSwitcher.ts
+++ b/support/pages/appSwitcher.ts
@@ -6,12 +6,26 @@ export class AppSwitcher {
   readonly drawIoBtn: Locator
   readonly appSwitcher: Locator
   externalSite: string
+  dashboardSite: string
 
   constructor(page: Page) {
     this.page = page
     this.drawIoBtn = this.page.locator('[data-test-id="app\\.draw-io\\.menuItem"]')
     this.appSwitcher = this.page.getByLabel('Application Switcher')
     this.externalSite = '[data-test-id="external-sites-%s"]'
+    this.dashboardSite = '[data-test-id="external-sites-dashboard-%s"]'
+  }
+
+  getExternalSite(site: string) {
+    return this.page.locator(util.format(this.externalSite, site))
+  }
+
+  getDashboard(name: string) {
+    return this.page.locator(util.format(this.dashboardSite, name))
+  }
+
+  async openDashboard(name: string) {
+    await this.getDashboard(name).click()
   }
 
   async clickAppSwitcher() {


### PR DESCRIPTION
## Description

This pull request adds a visibility feature for external sites via the user groups. 
It is totally optional and backwards compatible.

It also extends the dashboard feature to allow the use of `target` and `priority`.

```yaml
visibility:
  groups:
    any: ['editor', 'admin'] # Must have editor OR admin
    all: ['verified'] # Must also have verified
    none: ['suspended'] # Must NOT have suspended
```


See full description [here](https://github.com/tiran133/web-extensions/blob/main/packages/web-app-external-sites/README.md)

## Motivation
One of my clients needed the ability to hide/show some Links in the menu for a certain group of people.
After a little tinkering, I came up with the idea to use user groups to achieve this requirement.
My first implementation was named access control, but this was misleading as the links are still available though the `config.json`
I renamed it to visibility control and made it clear in the README that it should not be used to hide sensitive links.


## Additional Information
I have also improved upon the dashboard feature, which was merged a week ago. It now allows the use of `target` and `priority` 

`embedded` dashboard sites are nested below the dashboard path.

Ex. `external-sites/my-dashboard/my-embedded-site`

I added a few e2e tests for the feature, which tests the visibility and the dashboard feature itself.
For that, I extended the test helper a bit, which might be useful in the future.

I hope you consider merging this. I would like my contributions to benefit the community.