### PR TITLE
fix(maps): map folder view

### DIFF
--- a/packages/web-app-maps/src/components/LocationFolderView.vue
+++ b/packages/web-app-maps/src/components/LocationFolderView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="ext:h-full">
     <no-content-message v-if="!pinLocations.length" icon="map-2">
       <template #message>
         <span v-text="$gettext('No files with location data')" />

--- a/packages/web-app-maps/src/index.ts
+++ b/packages/web-app-maps/src/index.ts
@@ -78,7 +78,6 @@ export default defineWebApplication({
                         name: 'map-2',
                         fillType: 'line'
                       },
-                      isScrollable: false,
                       component: LocationFolderView,
                       componentAttrs: () => ({ applicationConfig })
                     }


### PR DESCRIPTION
Fix the display of the map folder view now that `isScrollable` has been removed/deprecated in Web (see https://github.com/opencloud-eu/web/pull/1390/commits/148189b828cb243cb8253aa5ecb3d784167454db).