### PR TITLE
chore: add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,45 @@
+name: 🐛 Bug report
+labels: Type:Bug
+description: Help us find bugs
+body:
+  - type: checkboxes
+    id: initial-checklist
+    attributes:
+      label: Initial Checklist
+      options:
+        - label: I understand this is a bug report and questions should be posted in
+            the [Community Discussions](https://github.com/orgs/opencloud-eu/discussions/)
+          required: true
+        - label: I searched
+            [issues](https://github.com/opencloud-eu/web-extensions/issues?q=is%3Aissue)
+            and couldn’t find anything (or linked relevant results below)
+          required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: Briefly describe the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Reproduction Steps
+      description: How did this happen? Please provide a [minimal, reproducible
+        example](https://stackoverflow.com/help/minimal-reproducible-example).
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Outcome
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Outcome
+      description: What actually happened?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,23 @@
+name: 🚀 Feature request
+labels: Type:Feature
+description: Share an idea for an existing or new extension
+body:
+  - type: checkboxes
+    id: initial-checklist
+    attributes:
+      label: Initial Checklist
+      options:
+        - label: I understand this is a feature request and questions should be posted in
+            the [Community Discussions](https://github.com/orgs/opencloud-eu/discussions/)
+          required: true
+        - label: I searched
+            [issues](https://github.com/opencloud-eu/web-extensions/issues?q=is%3Aissue)
+            and couldn’t find anything (or linked relevant results below)
+          required: true
+  - type: textarea
+    id: idea
+    attributes:
+      label: Idea
+      description: Briefly describe what you'd like to achieve.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3-user-story.yml
+++ b/.github/ISSUE_TEMPLATE/3-user-story.yml
@@ -1,0 +1,55 @@
+name: 👩🏽‍💻 User story
+labels: Type:Story
+description: Share an idea with clear user value
+body:
+  - type: checkboxes
+    id: initial-checklist
+    attributes:
+      label: Initial Checklist
+      options:
+        - label: I understand this is a user story and questions should be posted in
+            the [Community Discussions](https://github.com/orgs/opencloud-eu/discussions/)
+          required: true
+        - label: I searched
+            [issues](https://github.com/opencloud-eu/web-extensions/issues?q=is%3Aissue)
+            and couldn’t find anything (or linked relevant results below)
+          required: true
+  - type: textarea
+    id: story
+    attributes:
+      label: User Story
+      description: As a ..., I want to ... so that ... (stick to whom, what, why)
+      value: As a ..., I want to ... so that ... (stick to whom, what, why)
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: User Value
+      description: Explain the benefit or value this enhancement will bring to users.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the specific conditions that must be met for the user story to be considered complete.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Reminder - Definition of Ready
+        - Everyone understands the value in the user story
+        - Acceptance criteria are defined
+        - All dependencies are identified
+        - Feature is seen from an end user's perspective
+        - Story is estimated
+        - Story points are under 20
+
+        ## Reminder - Definition of Done
+        - Described functionality works
+        - Acceptance criteria are met
+        - Critical code has unit tests
+        - Prominent features have E2E tests
+        - PR checks are green

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🙋 Ask a question
+    url: https://github.com/orgs/opencloud-eu/discussions
+    about: Ask questions and discuss with other community members

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!--
+Thank you for your contribution to OpenCloud!
+
+For reporting potential security issues, contact us via https://opencloud.eu/
+
+Please follow these guidelines while opening a pull request:
+
+- Set appropriate labels
+- Assign it to yourself.
+- Choose at least one reviewer.
+-->
+
+## Description
+
+<!--- Describe the subject of the pull request in detail, if appropriate add screenshots  -->
+
+## Related Issue
+
+<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
+<!--- Link the issue here: -->
+
+- Fixes <issue_link>
+
+## How Has This Been Tested?
+
+<!--- Provide a brief description of how you tested your changes. -->
+<!--- Include your testing environment and the tests you ran. -->
+
+- test environment:
+- test case 1:
+- test case 2:
+- ...
+
+## Types of changes
+
+<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->
+
+- [ ] Bugfix
+- [ ] Enhancement (a change that doesn't break existing code or deployments)
+- [ ] Breaking change (a modification that affects current functionality)
+- [ ] Technical debt (addressing code that needs refactoring or improvements)
+- [ ] Tests (adding or improving tests)
+- [ ] Documentation (updates or additions to documentation)
+- [ ] Maintenance (like dependency updates or tooling adjustments)


### PR DESCRIPTION
This PR adds templates for PRs and issues, mostly just copying them from the web repo (and adjusting the wording a little bit for the context of this repo).