### PR TITLE
chore(json-viewer): fix security alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2933,8 +2933,8 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  svelte@5.46.0:
-    resolution: {integrity: sha512-ZhLtvroYxUxr+HQJfMZEDRsGsmU46x12RvAv/zi9584f5KOX7bUrEbhPJ7cKFmUvZTJXi/CFZUYwDC6M1FigPw==}
+  svelte@5.46.4:
+    resolution: {integrity: sha512-VJwdXrmv9L8L7ZasJeWcCjoIuMRVbhuxbss0fpVnR8yorMmjNDwcjIH08vS6wmSzzzgAG5CADQ1JuXPS2nwt9w==}
     engines: {node: '>=18'}
 
   tabbable@6.4.0:
@@ -6153,7 +6153,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svelte@5.46.0:
+  svelte@5.46.4:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6307,7 +6307,7 @@ snapshots:
       lodash-es: 4.17.22
       memoize-one: 6.0.0
       natural-compare-lite: 1.4.0
-      svelte: 5.46.0
+      svelte: 5.46.4
       vanilla-picker: 2.12.3
 
   vanilla-picker@2.12.3:


### PR DESCRIPTION
* bump `devalue` to v5.6.2
* bump `svelte` to v5.46.4