### PR TITLE
chore: replace nginx base image with busybox

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,10 @@
-FROM nginx@sha256:6c9ab46b34b89274be77bf50253f97bf8f16eb11b98128d5694a8ae9b3efa2ed
+FROM busybox@sha256:b9598f8c98e24d0ad42c1742c32516772c3aa2151011ebaf639089bd18c605b8
+
+ARG app_path
+ARG app_name
 
 LABEL maintainer="OpenCloud GmbH <devops@opencloud.eu>" \
-  org.opencontainers.image.title="OpenCloud Web Extensions" \
+  org.opencontainers.image.title="OpenCloud Web Extensions - $app_name" \
   org.opencontainers.image.description="OpenCloud Web Extensions" \
   org.opencontainers.image.vendor="OpenCloud GmbH" \
   org.opencontainers.image.authors="OpenCloud GmbH" \
@@ -10,15 +13,9 @@ LABEL maintainer="OpenCloud GmbH <devops@opencloud.eu>" \
   org.opencontainers.image.url="https://hub.docker.com/r/opencloudeu/web-extensions" \
   org.opencontainers.image.source="https://github.com/opencloud-eu/web-extensions"
 
-ARG app_path
-ARG app_name
+ADD $app_path /web/apps/$app_name
+# backwards compatibility: previous images used nginx and served from /usr/share/nginx/html
+RUN mkdir -p /usr/share/nginx && ln -s /web/apps /usr/share/nginx/html \
+  && find /web/apps
 
-RUN rm -f /usr/share/nginx/html/*
-
-ADD $app_path /usr/share/nginx/html/$app_name
-RUN find /usr/share/nginx/html
-
-STOPSIGNAL SIGTERM
-
-CMD ["nginx", "-g", "daemon off;"]
-WORKDIR /usr/share/nginx/html
+WORKDIR /web/apps


### PR DESCRIPTION
## Summary
- Replace the ~180MB nginx base image with a ~4MB busybox image (pinned by digest)
- OpenCloud serves web extensions directly, so the nginx web server in the container has become unused
- Move app files to `/web/apps/` to match the `WEB_ASSET_APPS_PATH` convention
- Symlink `/usr/share/nginx/html` → `/web/apps` for backwards compatibility with existing deployments
- Remove nginx-specific directives (`CMD`, `STOPSIGNAL`, html dir cleanup)
- Include `app_name` in the OCI `image.title` label

## Test plan
- [x] Build a Docker image for one of the apps and verify the files are at `/web/apps/<app_name>`
- [x] Verify `cp -r /usr/share/nginx/html/<app_name>` still works via the symlink
- [x] Deploy the image and verify OpenCloud can load the extension from the container