### PR TITLE
chore(docker): add IDP config with additional redirect URIs

### DIFF
--- a/dev/docker/opencloud.idp.config.yaml
+++ b/dev/docker/opencloud.idp.config.yaml
@@ -1,0 +1,16 @@
+clients:
+  - id: web
+    name: OpenCloud web app
+    application_type: web
+    insecure: true
+    trusted: true
+    redirect_uris:
+      - https://host.docker.internal:9200/
+      - https://host.docker.internal:9200/oidc-callback.html
+      - https://host.docker.internal:9200/oidc-silent-redirect.html
+      - https://host.docker.internal:9201/
+      - https://host.docker.internal:9201/oidc-callback.html
+      - https://host.docker.internal:9201/oidc-silent-redirect.html
+    origins:
+      - https://host.docker.internal:9200
+      - https://host.docker.internal:9201

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       traefik.http.routers.opencloud.middlewares: cors
     volumes:
       - opencloud-config:/etc/opencloud
+      - ./dev/docker/opencloud.idp.config.yaml:/etc/opencloud/idp.yaml
       - ./dev/docker/opencloud.web.config.json:/web/config.json
       - ./dev/docker/opencloud.apps.yaml:/etc/opencloud/apps.yaml
       - ./dev/docker/csp.yaml:/etc/opencloud/csp.yaml


### PR DESCRIPTION
## Summary
- Add `opencloud.idp.config.yaml` with redirect URIs for both port 9200 (OpenCloud) and 9201 (dev frontend)
- Mount the IDP config in the docker-compose OpenCloud service
- Mirrors the setup from the web repo, allowing developers to run a separate frontend for debugging