### PR TITLE
chore: bump published packages to next major version (ESM)

### DIFF
--- a/packages/web-app-arcade/CHANGELOG.md
+++ b/packages/web-app-arcade/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/arcade-v2.0.0) - 2026-04-07
+
+### Breaking changes
+
+- The extension is now bundled as ESM instead of AMD and only loads with OpenCloud versions >= 6.
+
 ## [1.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/arcade-v1.0.0) - 2025-10-01
 
 ### ✨ Features

--- a/packages/web-app-arcade/package.json
+++ b/packages/web-app-arcade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-app-arcade",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "open and play .nes ROMs in OpenCloud Web Arcade",
   "license": "AGPL-3.0",

--- a/packages/web-app-calculator/CHANGELOG.md
+++ b/packages/web-app-calculator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/calculator-v2.0.0) - 2026-04-07
+
+### Breaking changes
+
+- The extension is now bundled as ESM instead of AMD and only loads with OpenCloud versions >= 6.
+
+### 📦️ Dependencies
+
+- Update dependency mathjs to v15 [[#427](https://github.com/opencloud-eu/web-extensions/pull/427)]
+
 ## [1.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/calculator-v1.0.0) - 2026-03-24
 
 ### ✨ Features

--- a/packages/web-app-calculator/package.json
+++ b/packages/web-app-calculator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-app-calculator",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "OpenCloud Web calculator search provider",
   "license": "AGPL-3.0",

--- a/packages/web-app-draw-io/CHANGELOG.md
+++ b/packages/web-app-draw-io/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/draw-io-v2.0.0) - 2026-04-07
+
+### Breaking changes
+
+- The extension is now bundled as ESM instead of AMD and only loads with OpenCloud versions >= 6.
+
 ## [1.0.1](https://github.com/opencloud-eu/web-extensions/releases/tag/draw-io-v1.0.1) - 2025-10-01
 
 ### 🐛 Bug Fixes

--- a/packages/web-app-draw-io/package.json
+++ b/packages/web-app-draw-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draw-io",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "private": true,
   "description": "OpenCloud web draw.io integration",
   "license": "AGPL-3.0",

--- a/packages/web-app-external-sites/CHANGELOG.md
+++ b/packages/web-app-external-sites/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/external-sites-v2.0.0) - 2026-04-07
+
+### Breaking changes
+
+- The extension is now bundled as ESM instead of AMD and only loads with OpenCloud versions >= 6.
+
 ## [1.3.0](https://github.com/opencloud-eu/web-extensions/releases/tag/external-sites-v1.3.0) - 2025-10-01
 
 ### ✨ Features

--- a/packages/web-app-external-sites/package.json
+++ b/packages/web-app-external-sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "external-sites",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "private": true,
   "description": "add external sites to the OpenCloud Web app menu",
   "license": "AGPL-3.0",

--- a/packages/web-app-json-viewer/CHANGELOG.md
+++ b/packages/web-app-json-viewer/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/json-viewer-v2.0.0) - 2026-04-07
+
+### Breaking changes
+
+- The extension is now bundled as ESM instead of AMD and only loads with OpenCloud versions >= 6.
+
+### 📦️ Dependencies
+
+- Update dependency vanilla-jsoneditor to v3.12.0[[#415](https://github.com/opencloud-eu/web-extensions/pull/415)]
+
 ## [1.0.2](https://github.com/opencloud-eu/web-extensions/releases/tag/json-viewer-v1.0.2) - 2025-10-01
 
 ### 🐛 Bug Fixes

--- a/packages/web-app-json-viewer/package.json
+++ b/packages/web-app-json-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-viewer",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "private": true,
   "description": "OpenCloud Web json-viewer",
   "license": "AGPL-3.0",

--- a/packages/web-app-maps/CHANGELOG.md
+++ b/packages/web-app-maps/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/maps-v3.0.0) - 2026-04-07
+
+### Breaking changes
+
+- The extension is now bundled as ESM instead of AMD and only loads with OpenCloud versions >= 6.
+
+### 📦️ Dependencies
+
+- Update dependency @tmcw/togeojson to v7 [[#369](https://github.com/opencloud-eu/web-extensions/pull/369)]
+
 ## [2.0.2](https://github.com/opencloud-eu/web-extensions/releases/tag/maps-v2.0.2) - 2026-03-13
 
 ### 🐛 Bug Fixes

--- a/packages/web-app-maps/package.json
+++ b/packages/web-app-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-app-maps",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "private": true,
   "description": "OpenCloud Web Maps",
   "license": "AGPL-3.0",

--- a/packages/web-app-pastebin/CHANGELOG.md
+++ b/packages/web-app-pastebin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/pastebin-v2.0.0) - 2026-04-07
+
+### Breaking changes
+
+- The extension is now bundled as ESM instead of AMD and only loads with OpenCloud versions >= 6.
+
 ## [1.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/pastebin-v1.0.0) - 2026-03-24
 
 ### ✨ Features

--- a/packages/web-app-pastebin/package.json
+++ b/packages/web-app-pastebin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pastebin",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "OpenCloud Web Pastebin",
   "license": "AGPL-3.0",

--- a/packages/web-app-progress-bars/CHANGELOG.md
+++ b/packages/web-app-progress-bars/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/progress-bars-v2.0.0) - 2026-04-07
+
+### Breaking changes
+
+- The extension is now bundled as ESM instead of AMD and only loads with OpenCloud versions >= 6.
+
 ## [1.1.0](https://github.com/opencloud-eu/web-extensions/releases/tag/progress-bars-v1.1.0) - 2025-10-01
 
 ### ✨ Features

--- a/packages/web-app-progress-bars/package.json
+++ b/packages/web-app-progress-bars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-app-progress-bars",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "private": true,
   "description": "OpenCloud Progress Bars",
   "license": "AGPL-3.0",

--- a/packages/web-app-unzip/CHANGELOG.md
+++ b/packages/web-app-unzip/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/unzip-v2.0.0) - 2026-04-07
+
+### Breaking changes
+
+- The extension is now bundled as ESM instead of AMD and only loads with OpenCloud versions >= 6.
+
+### 📦️ Dependencies
+
+- Update dependency @zip.js/zip.js to v2.8.26 [[#418](https://github.com/opencloud-eu/web-extensions/pull/418)]
+
 ## [1.0.4](https://github.com/opencloud-eu/web-extensions/releases/tag/unzip-v1.0.4) - 2025-10-27
 
 ### 📦️ Dependencies

--- a/packages/web-app-unzip/package.json
+++ b/packages/web-app-unzip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-app-unzip",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "private": true,
   "description": "OpenCloud Web unzip",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary

- Bump all published packages (except `web-app-cast`, `web-app-importer`, `web-app-notes`) to their next major version
- Add changelog entries noting that extensions are now bundled as ESM instead of AMD and only load with OpenCloud versions >= 6

## Changed packages

| Package | Old version | New version |
|---------|-------------|-------------|
| web-app-arcade | 1.0.0 | 2.0.0 |
| web-app-calculator | 1.0.0 | 2.0.0 |
| web-app-draw-io | 1.0.1 | 2.0.0 |
| web-app-external-sites | 1.3.0 | 2.0.0 |
| web-app-json-viewer | 1.0.2 | 2.0.0 |
| web-app-maps | 2.0.2 | 3.0.0 |
| web-app-pastebin | 1.0.0 | 2.0.0 |
| web-app-progress-bars | 1.1.0 | 2.0.0 |
| web-app-unzip | 1.0.4 | 2.0.0 |

🤖 Generated with [Claude Code](https://claude.com/product/claude-code)