### PR TITLE
Fix z-index order of GPX overlay + color class refactor

### DIFF
--- a/packages/web-app-external-sites/src/components/DashboardLink.vue
+++ b/packages/web-app-external-sites/src/components/DashboardLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <oc-card class="bg-role-surface-container ext:border">
+  <oc-card class="ext:bg-role-surface-container ext:border">
     <component :is="site.target === 'embedded' ? 'router-link' : 'a'" v-bind="linkProps">
       <div class="ext:flex ext:items-center ext:gap-4">
         <oc-icon v-if="site.icon" :name="site.icon" :color="site.color" size="large" />

--- a/packages/web-app-maps/src/components/GpxMap.vue
+++ b/packages/web-app-maps/src/components/GpxMap.vue
@@ -2,7 +2,7 @@
   <div class="ext:flex ext:flex-col ext:relative ext:size-full">
     <div ref="mapElement" class="ext:size-full ext:z-1" />
     <dl
-      class="ext:absolute ext:grid ext:grid-cols-[auto_minmax(0,1fr)] ext:gap-x-4 ext:z-990 bg-role-surface-container ext:opacity-90 ext:backdrop-blur-sm ext:rounded ext:p-3 ext:right-2 ext:top-2 ext:text-sm ext:shadow-sm"
+      class="ext:absolute ext:grid ext:grid-cols-[auto_minmax(0,1fr)] ext:gap-x-4 ext:z-990 ext:bg-role-surface-container/80 ext:backdrop-blur-sm ext:rounded ext:p-3 ext:right-2 ext:top-2 ext:text-sm ext:shadow-sm"
     >
       <dt v-text="$gettext('Name')" />
       <dd>{{ meta.name }}</dd>

--- a/packages/web-app-maps/src/components/GpxMap.vue
+++ b/packages/web-app-maps/src/components/GpxMap.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="ext:flex ext:flex-col ext:relative ext:size-full">
-    <div ref="mapElement" class="ext:size-full ext:z-1" />
+    <div ref="mapElement" class="ext:size-full" />
     <dl
-      class="ext:absolute ext:grid ext:grid-cols-[auto_minmax(0,1fr)] ext:gap-x-4 ext:z-990 ext:bg-role-surface-container/80 ext:backdrop-blur-sm ext:rounded ext:p-3 ext:right-2 ext:top-2 ext:text-sm ext:shadow-sm"
+      class="ext:absolute ext:grid ext:grid-cols-[auto_minmax(0,1fr)] ext:gap-x-4 ext:bg-role-surface-container/80 ext:backdrop-blur-sm ext:rounded ext:p-3 ext:right-2 ext:top-2 ext:text-sm ext:shadow-sm"
     >
       <dt v-text="$gettext('Name')" />
       <dd>{{ meta.name }}</dd>

--- a/packages/web-app-notes/src/components/TocFolder.vue
+++ b/packages/web-app-notes/src/components/TocFolder.vue
@@ -2,7 +2,7 @@
   <div
     class="ext:w-100 toc-item-wrapper"
     :class="{
-      'bg-role-secondary-container': isDragOverNode(node),
+      'ext:bg-role-secondary-container': isDragOverNode(node),
       'ext:rounded': isDragOverNode(node)
     }"
     @dragover.prevent="onDragOverFolder(node)"

--- a/packages/web-app-notes/src/components/TocWrapper.vue
+++ b/packages/web-app-notes/src/components/TocWrapper.vue
@@ -17,7 +17,7 @@
       <div
         v-if="isDragAndDropActive"
         class="ext:h-30 ext:border ext:border-dashed ext:flex ext:items-center ext:justify-center"
-        :class="{ 'bg-role-secondary-container': dragOverRoot, 'ext:rounded': dragOverRoot }"
+        :class="{ 'ext:bg-role-secondary-container': dragOverRoot, 'ext:rounded': dragOverRoot }"
         :aria-label="$gettext('Root drop zone')"
         @dragover.prevent="onDragOverRoot()"
         @dragleave="onDragLeaveRoot"

--- a/packages/web-app-pastebin/src/Edit.vue
+++ b/packages/web-app-pastebin/src/Edit.vue
@@ -8,10 +8,10 @@
       v-else-if="error || isReadOnly"
       class="ext:flex ext:flex-col ext:items-center ext:justify-center ext:h-full ext:text-center"
     >
-      <h2 class="ext:text-[var(--oc-role-error)] ext:mb-4">
+      <h2 class="ext:text-role-error ext:mb-4">
         {{ isReadOnly ? $gettext('Read-only') : $gettext('Failed to load') }}
       </h2>
-      <p class="ext:text-[var(--oc-role-on-surface-variant)]">
+      <p class="ext:text-role-on-surface-variant">
         {{ isReadOnly ? $gettext('This pastebin is read-only.') : error }}
       </p>
       <oc-button

--- a/packages/web-app-pastebin/src/List.vue
+++ b/packages/web-app-pastebin/src/List.vue
@@ -23,7 +23,7 @@
 
         <div
           v-else-if="pastebins.length === 0"
-          class="ext:text-center ext:py-12 ext:text-[var(--oc-role-on-surface-variant)]"
+          class="ext:text-center ext:py-12 ext:text-role-on-surface-variant"
         >
           <p class="ext:mb-4">{{ $gettext('No pastebins yet.') }}</p>
           <oc-button
@@ -41,22 +41,17 @@
             v-for="pb in pastebins"
             :key="pb.id"
             :to="getPastebinRoute(pb)"
-            class="pastebin-item ext:flex ext:items-center ext:gap-3 ext:px-4 ext:py-3 ext:rounded-lg ext:border ext:border-[var(--oc-role-outline-variant)] ext:bg-[var(--oc-role-surface)] ext:no-underline ext:text-[var(--oc-role-on-surface)]"
+            class="pastebin-item ext:flex ext:items-center ext:gap-3 ext:px-4 ext:py-3 ext:rounded-lg ext:border ext:border-role-outline-variant ext:bg-role-surface ext:no-underline ext:text-role-on-surface"
           >
-            <oc-icon
-              name="file-text"
-              size="small"
-              class="ext:text-[var(--oc-role-on-surface-variant)]"
-            />
+            <oc-icon name="file-text" size="small" class="ext:text-role-on-surface-variant" />
             <div class="ext:flex-1 ext:min-w-0">
               <div class="ext:text-sm ext:font-medium ext:truncate">
                 {{ getPastebinDisplayName(pb) }}
               </div>
             </div>
-            <span
-              class="ext:text-xs ext:text-[var(--oc-role-on-surface-variant)] ext:whitespace-nowrap"
-              >{{ formatDate(pb.mdate, currentLanguage) }}</span
-            >
+            <span class="ext:text-xs ext:text-role-on-surface-variant ext:whitespace-nowrap">{{
+              formatDate(pb.mdate, currentLanguage)
+            }}</span>
             <oc-button
               appearance="raw"
               size="small"

--- a/packages/web-app-pastebin/src/View.vue
+++ b/packages/web-app-pastebin/src/View.vue
@@ -8,8 +8,8 @@
       v-else-if="error"
       class="ext:flex ext:flex-col ext:items-center ext:justify-center ext:h-full ext:text-center"
     >
-      <h2 class="ext:text-[var(--oc-role-error)] ext:mb-4">{{ $gettext('Failed to load') }}</h2>
-      <p class="ext:text-[var(--oc-role-on-surface-variant)]">{{ error }}</p>
+      <h2 class="ext:text-role-error ext:mb-4">{{ $gettext('Failed to load') }}</h2>
+      <p class="ext:text-role-on-surface-variant">{{ error }}</p>
     </div>
 
     <template v-else>
@@ -68,7 +68,7 @@
         <div class="ext:max-w-4xl ext:mx-auto">
           <div
             v-if="folderResources.length === 0"
-            class="ext:text-center ext:py-12 ext:text-[var(--oc-role-on-surface-variant)]"
+            class="ext:text-center ext:py-12 ext:text-role-on-surface-variant"
           >
             {{ $gettext('No files in this pastebin.') }}
           </div>

--- a/packages/web-app-pastebin/src/components/AppHeader.vue
+++ b/packages/web-app-pastebin/src/components/AppHeader.vue
@@ -1,10 +1,10 @@
 <template>
   <header
-    class="ext:flex ext:items-center ext:justify-between ext:px-5 ext:py-4 ext:border-b ext:border-[var(--oc-role-outline-variant)] ext:bg-[var(--oc-role-surface-container)]"
+    class="ext:flex ext:items-center ext:justify-between ext:px-5 ext:py-4 ext:border-b ext:border-role-outline-variant ext:bg-role-surface-container"
   >
     <nav
       aria-label="Breadcrumb"
-      class="ext:m-0 ext:text-xl ext:font-semibold ext:text-[var(--oc-role-on-surface)] ext:flex ext:items-center ext:min-w-0"
+      class="ext:m-0 ext:text-xl ext:font-semibold ext:text-role-on-surface ext:flex ext:items-center ext:min-w-0"
     >
       <slot name="title" />
     </nav>

--- a/packages/web-app-pastebin/src/components/PastebinEditor.vue
+++ b/packages/web-app-pastebin/src/components/PastebinEditor.vue
@@ -1,15 +1,15 @@
 <template>
   <div
-    class="ext:rounded-md ext:border ext:border-[var(--oc-role-outline-variant)] ext:overflow-hidden ext:bg-[var(--oc-role-surface)]"
+    class="ext:rounded-md ext:border ext:border-role-outline-variant ext:overflow-hidden ext:bg-role-surface"
   >
     <div
-      class="ext:flex ext:items-center ext:justify-between ext:px-3 ext:py-2 ext:bg-[var(--oc-role-surface-container)] ext:border-b ext:border-[var(--oc-role-outline-variant)]"
+      class="ext:flex ext:items-center ext:justify-between ext:px-3 ext:py-2 ext:bg-role-surface-container ext:border-b ext:border-role-outline-variant"
     >
       <input
         :value="filename"
         type="text"
         :aria-label="$gettext('Filename')"
-        class="ext:w-[260px] ext:border ext:border-[var(--oc-role-outline-variant)] ext:rounded ext:px-2 ext:py-0.5 ext:font-mono ext:text-xs ext:bg-[var(--oc-role-surface)] ext:text-[var(--oc-role-on-surface)] ext:outline-none focus:ext:border-[var(--oc-role-primary)]"
+        class="ext:w-[260px] ext:border ext:border-role-outline-variant ext:rounded ext:px-2 ext:py-0.5 ext:font-mono ext:text-xs ext:bg-role-surface ext:text-role-on-surface ext:outline-none focus:ext:border-role-primary"
         :placeholder="$gettext('Filename including extension…')"
         @input="$emit('update:filename', ($event.target as HTMLInputElement).value)"
       />
@@ -26,21 +26,18 @@
     <div class="editor-body ext:flex">
       <div
         ref="lineNumbersRef"
-        class="line-numbers ext:bg-[var(--oc-role-surface-container)] ext:border-r ext:border-[var(--oc-role-outline-variant)]"
+        class="line-numbers ext:bg-role-surface-container ext:border-r ext:border-role-outline-variant"
         aria-hidden="true"
       >
-        <span
-          v-for="n in lineCount"
-          :key="n"
-          class="ext:text-[var(--oc-role-on-surface-variant)]"
-          >{{ n }}</span
-        >
+        <span v-for="n in lineCount" :key="n" class="ext:text-role-on-surface-variant">{{
+          n
+        }}</span>
       </div>
       <textarea
         ref="textareaRef"
         :value="content"
         :aria-label="$gettext('File content')"
-        class="code-textarea ext:flex-1 ext:text-[var(--oc-role-on-surface)] ext:bg-[var(--oc-role-surface)]"
+        class="code-textarea ext:flex-1 ext:text-role-on-surface ext:bg-role-surface"
         spellcheck="false"
         @input="$emit('update:content', ($event.target as HTMLTextAreaElement).value)"
         @scroll="syncScroll"

--- a/packages/web-app-pastebin/src/components/PastebinFile.vue
+++ b/packages/web-app-pastebin/src/components/PastebinFile.vue
@@ -1,17 +1,16 @@
 <template>
   <div
     :data-item-id="resource.name"
-    class="pastebin-file ext:rounded-lg ext:border ext:border-[var(--oc-role-outline-variant)] ext:overflow-hidden ext:bg-[var(--oc-role-surface)] ext:mb-6"
+    class="pastebin-file ext:rounded-lg ext:border ext:border-role-outline-variant ext:overflow-hidden ext:bg-role-surface ext:mb-6"
   >
     <div
-      class="ext:flex ext:items-center ext:px-4 ext:py-2.5 ext:bg-[var(--oc-role-surface-container)] ext:border-b ext:border-[var(--oc-role-outline-variant)] ext:cursor-pointer"
+      class="ext:flex ext:items-center ext:px-4 ext:py-2.5 ext:bg-role-surface-container ext:border-b ext:border-role-outline-variant ext:cursor-pointer"
       @click="scrollToSelf"
     >
       <ResourceIcon :resource="resource" size="small" class="ext:mr-2" />
-      <span
-        class="ext:font-mono ext:text-sm ext:font-medium ext:text-[var(--oc-role-on-surface)]"
-        >{{ resource.name }}</span
-      >
+      <span class="ext:font-mono ext:text-sm ext:font-medium ext:text-role-on-surface">{{
+        resource.name
+      }}</span>
       <oc-button
         v-if="anchorHref"
         appearance="raw"
@@ -47,10 +46,7 @@
       <div v-if="loading" class="ext:flex ext:justify-center ext:py-8">
         <oc-spinner size="small" :aria-label="$gettext('Loading pastebin')" />
       </div>
-      <div
-        v-else-if="error"
-        class="ext:p-6 ext:text-center ext:text-sm ext:text-[var(--oc-role-error)]"
-      >
+      <div v-else-if="error" class="ext:p-6 ext:text-center ext:text-sm ext:text-role-error">
         {{ error }}
       </div>
       <div v-else-if="content" class="ext:overflow-x-auto">


### PR DESCRIPTION
<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

<!--- Describe the subject of the pull request in detail, if appropriate add screenshots  -->

 1\) Use oc color roles via generated tailwind utility classes https://github.com/opencloud-eu/web/pull/2339


2\) Fix z-index order of maps GPX overlay

Before/After:

<img width="362" height="196" alt="image" src="https://github.com/user-attachments/assets/0f9f4066-6cec-41f6-8acf-1da30b59f25b" />

<img width="363" height="203" alt="image" src="https://github.com/user-attachments/assets/426546c1-a708-4df8-868e-65076a1b3b7e" />



## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Ref: #380 

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
