### PR TITLE
fix(e2e): make pastebin share helpers resilient to async clipboard writes

### DIFF
--- a/support/pages/pastebinPage.ts
+++ b/support/pages/pastebinPage.ts
@@ -130,17 +130,35 @@ export class PastebinPage {
     await this.page.locator('.oc-modal-body-actions-confirm').click()
   }
 
-  // Share links — clicks the button to copy to clipboard and reads back the content
+  // Share links — clicks the button to copy to clipboard and reads back the content.
+  // The app uses `useClipboard` which writes asynchronously, and other flows
+  // (e.g. password-link creation) may have written a stale value already, so we
+  // clear the clipboard first and poll until the click handler has written a new one.
+  private async clickAndReadClipboard(click: () => Promise<void>): Promise<string> {
+    await this.page.evaluate(() => navigator.clipboard.writeText(''))
+    await click()
+    let value = ''
+    await expect
+      .poll(
+        async () => {
+          value = await this.page.evaluate(() => navigator.clipboard.readText())
+          return value.length
+        },
+        { timeout: 5000 }
+      )
+      .toBeGreaterThan(0)
+    return value
+  }
+
   async getShareLinkHref(): Promise<string> {
-    const btn = this.page.locator('header button[title="Copy public link"]')
-    await btn.click()
-    return this.page.evaluate(() => navigator.clipboard.readText())
+    return this.clickAndReadClipboard(() =>
+      this.page.locator('header button[title="Copy public link"]').click()
+    )
   }
 
   async getAnchorHref(filename: string): Promise<string> {
-    const container = this.getFileContainer(filename)
-    const btn = container.locator('button[title="Link to this file"]')
-    await btn.click()
-    return this.page.evaluate(() => navigator.clipboard.readText())
+    return this.clickAndReadClipboard(() =>
+      this.getFileContainer(filename).locator('button[title="Link to this file"]').click()
+    )
   }
 }


### PR DESCRIPTION

<!--
Thank you for your contribution to OpenCloud!

For reporting potential security issues, contact us via https://opencloud.eu/

Please follow these guidelines while opening a pull request:

- Set appropriate labels
- Assign it to yourself.
- Choose at least one reviewer.
-->

## Description

getShareLinkHref/getAnchorHref in support/pages/pastebinPage.ts read the clipboard immediately after clicking the copy button. The app uses @vueuse/core useClipboard() to perform the actual write, and other flows (e.g. password-link creation) may have left a stale "URL\nPassword: ..." value in the clipboard. As a result, the helpers occasionally returned a stale value (e.g. the same alpha link for both alpha and beta).

This is a latent race that became reliably reproducible once @vueuse/core was bumped from 14.2.1 to 14.3.0 (the "useClipboard: Prevents fail in Safari for async operation" change shifted the write to be more asynchronous in Chromium too), which is why the `public links` tests started failing on PR #439.

Clear the clipboard before clicking and poll until the click handler has written a new non-empty value.

## Related Issue

<!--- If you are fixing a bug, please ensure there's an issue detailing the steps to reproduce it. -->
<!--- Link the issue here: -->

- Fixes <issue_link>

## How Has This Been Tested?

<!--- Provide a brief description of how you tested your changes. -->
<!--- Include your testing environment and the tests you ran. -->

- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes

<!--- What types of changes does your code introduce? Mark an x in all the applicable boxes: -->

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
