### PR TITLE
fix: hide pastebin and notes app menu entries on public pages

### DIFF
--- a/packages/web-app-notes/src/index.ts
+++ b/packages/web-app-notes/src/index.ts
@@ -3,7 +3,8 @@ import {
   defineWebApplication,
   AppMenuItemExtension,
   ApplicationInformation,
-  AppWrapperRoute
+  AppWrapperRoute,
+  useUserStore
 } from '@opencloud-eu/web-pkg'
 import { urlJoin } from '@opencloud-eu/web-client'
 import translations from '../l10n/translations.json'
@@ -16,6 +17,7 @@ import View from './views/View.vue'
 export default defineWebApplication({
   setup() {
     const { $gettext } = useGettext()
+    const userStore = useUserStore()
 
     const routes = [
       {
@@ -59,6 +61,7 @@ export default defineWebApplication({
     }
 
     const menuItems = computed<AppMenuItemExtension[]>(() => {
+      if (!userStore.user) return []
       return [
         {
           id: `app.${appInfo.id}.menuItem`,

--- a/packages/web-app-pastebin/src/index.ts
+++ b/packages/web-app-pastebin/src/index.ts
@@ -4,7 +4,8 @@ import {
   AppMenuItemExtension,
   AppWrapperRoute,
   ApplicationInformation,
-  defineWebApplication
+  defineWebApplication,
+  useUserStore
 } from '@opencloud-eu/web-pkg'
 import { urlJoin } from '@opencloud-eu/web-client'
 import { computed } from 'vue'
@@ -21,6 +22,7 @@ const applicationId = 'pastebin'
 export default defineWebApplication({
   setup() {
     const { $gettext } = useGettext()
+    const userStore = useUserStore()
 
     const routes = [
       {
@@ -78,16 +80,19 @@ export default defineWebApplication({
       ]
     }
 
-    const menuItems = computed<AppMenuItemExtension[]>(() => [
-      {
-        id: `app.${applicationId}.menuItem`,
-        type: 'appMenuItem',
-        label: () => $gettext('Pastebin'),
-        icon: 'upload',
-        path: urlJoin(applicationId),
-        color: 'white'
-      }
-    ])
+    const menuItems = computed<AppMenuItemExtension[]>(() => {
+      if (!userStore.user) return []
+      return [
+        {
+          id: `app.${applicationId}.menuItem`,
+          type: 'appMenuItem',
+          label: () => $gettext('Pastebin'),
+          icon: 'upload',
+          path: urlJoin(applicationId),
+          color: 'white'
+        }
+      ]
+    })
 
     return {
       appInfo,


### PR DESCRIPTION
## Description

The pastebin and notes app-switcher entries appeared on public-link views where no user is logged in. Both items link to user-space routes that anonymous visitors cannot use. Guard `menuItems` with `userStore.user`, matching the existing `web-app-draw-io` pattern.

Opening `.pastebin` folders or `.ocnb` files via public links is unaffected; that flow uses `appInfo.extensions` with `authContext: 'hybrid'`, independent of the menu item.

## Related Issue

- Fixes #413

## How Has This Been Tested?

- test environment: type-check, prettier, eslint locally
- test case 1: `vue-tsc --noEmit` clean for both packages
- test case 2 (manual, recommended before merge): enable pastebin + notes, open a public folder link unauthenticated, app switcher should show neither entry; `.pastebin` / `.ocnb` via public link should still open

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
