### PR TITLE
fix(unzip): preserve subfolder structure when extracting archives

### DIFF
--- a/packages/web-app-unzip/src/composables/useUnzipAction.ts
+++ b/packages/web-app-unzip/src/composables/useUnzipAction.ts
@@ -23,6 +23,11 @@ import workerUrl from '@zip.js/zip.js/dist/zip-web-worker.js?worker&url'
 const SUPPORTED_MIME_TYPES = ['application/zip']
 const MAX_SIZE_MB = 64 // in mb
 
+// uppy's convention for directory-upload metadata on the file object. mirrors the
+// (non-exported) FileWithPath in web/packages/web-pkg/src/services/uppy/uppyService.ts.
+// uppyService.getRelativeFilePath reads .relativePath from file.data.
+type FileWithPath = Blob & { relativePath?: string }
+
 export const useUnzipAction = () => {
   const { $gettext, current: currentLanguage } = useGettext()
   const clientService = useClientService()
@@ -88,13 +93,16 @@ export const useUnzipAction = () => {
             const path = dirname(result.filename)
             const name = path === '.' ? result.filename : result.filename.substring(path.length + 1)
 
+            if (path !== '.') {
+              // attach relativePath to the data blob so uppyService preserves
+              // the subfolder structure when uploading the extracted files.
+              ;(data as FileWithPath).relativePath = urlJoin(path, name)
+            }
+
             return {
               name,
               data,
-              meta: {
-                ...(path !== '.' && { webkitRelativePath: urlJoin(path, name) }),
-                uploadId
-              }
+              meta: { uploadId }
             } as unknown as OcMinimalUppyFile
           })
         })

--- a/packages/web-app-unzip/tests/e2e/extractZip.spec.ts
+++ b/packages/web-app-unzip/tests/e2e/extractZip.spec.ts
@@ -15,18 +15,33 @@ test.afterEach(async () => {
   await logout(userPage)
 })
 
-// FIXME: currently skipped because of https://github.com/opencloud-eu/web/pull/2506
-// unskip with the next OpenCloud release (v7 probably)
-test.skip('extract zip file', async () => {
+// FIXME: skipped until the bundled OpenCloud image ships a web build that contains
+// both:
+//   - https://github.com/opencloud-eu/web/pull/2506 (services announced before apps
+//     init, otherwise uppyService is undefined when the extract handler runs and the
+//     archive extraction fails)
+//   - https://github.com/opencloud-eu/web/pull/2513 (suppresses a false-positive
+//     "Folder already exists" dialog that fires whenever the zip's top-level folder
+//     name matches anything in the user's current folder, which is the case for
+//     data.zip)
+test.skip('extract zip file preserves subfolder structure', async () => {
   const uploadFile = new FilesAppBar(userPage)
   await uploadFile.uploadFile('data.zip')
 
   const file = new FilesPage(userPage)
   await file.extractZip('data.zip')
 
+  // extraction creates a folder named after the archive
   await file.openFolder('data')
-  await expect(
-    userPage.locator('span.oc-resource-basename', { hasText: 'logo-wide' })
-  ).toBeVisible()
-  await expect(userPage.locator('span.oc-resource-basename', { hasText: 'lorem' })).toBeVisible()
+  // the zip's own top-level "data/" folder must be preserved inside
+  await expect(userPage.locator('[data-test-resource-name="data"]')).toBeVisible()
+
+  await file.openFolder('data')
+  await expect(userPage.locator('[data-test-resource-name="logo-wide.png"]')).toBeVisible()
+  await expect(userPage.locator('[data-test-resource-name="lorem.txt"]')).toBeVisible()
+  await expect(userPage.locator('[data-test-resource-name="dir"]')).toBeVisible()
+
+  // nested subfolder content must be preserved, not flattened
+  await file.openFolder('dir')
+  await expect(userPage.locator('[data-test-resource-name="lorem.txt"]')).toBeVisible()
 })


### PR DESCRIPTION
## Description

Extracted files lost their subfolder paths and ended up flat inside the extraction folder. For example, extracting `maps-1.0.2.zip` (which contains `js/maps-uKkx1qsf.js`) put `maps-uKkx1qsf.js` directly into the extraction folder instead of inside `js/`.

### Root cause

The handler set `webkitRelativePath` on `file.meta`, but `uppyService.onBeforeFileAdded` unconditionally recomputes `meta.relativePath` from `file.data.relativePath || file.data.webkitRelativePath`. Neither of those was being set on the blob by the unzip handler. Result: `meta.relativePath` was always `undefined` for extracted files, so `HandleUpload` treated them all as root-level and didn't create the nested directory tree.

This regressed in opencloud-eu/web@`e1828e7f70` (*refactor: switch back to upstream uppy*, 2024-12-20), which dropped the `file.meta.relativePath || file.meta.webkitRelativePath` fallback in `HandleUpload`. From that point on, only `file.data.*` was consulted, but the unzip handler wasn't writing there.

### Affected web versions

The fallback was removed in web@`e1828e7f70` (2024-12-20) and first shipped in **web v1.0.0** (2025-02-25). Module federation (the runtime mechanism that loads this extension) was added in web@`f496f9a9f4` (2026-03-24), first shipped in **web v6.1.0**. This unzip build pins `@opencloud-eu/web-pkg: ^7.0.0`, so it can only load into web v7.0.0+ at runtime. Every web version that can load this bundle has the regression. There is no host where the old `meta.*` fallback still works.

### Fix

Attach `relativePath` directly to the data blob. This matches uppy's convention, the same one used by `DropTarget.getDroppedFiles` for drag-and-drop folder uploads (`web`, `packages/web-pkg/src/services/uppy/DropTarget/getDroppedFiles.ts:17`). `uppyService` now picks it up, populates `meta.relativePath`, and `HandleUpload` creates the nested directory tree as expected.

### Test

The e2e test (extended to assert the preserved subfolder structure for `data.zip`) currently has to stay `skipped` because the OpenCloud rolling image bundles web v7.0.0, which is missing two prerequisite web fixes:

1. **opencloud-eu/web#2506** (*service announcement order*, merged 2026-05-13): without it, `useService<UppyService>('$uppyService')` returns undefined when the unzip handler runs, the extract throws, and the catch shows "Failed to extract archive". This is the same reason the test was originally skipped.
2. **opencloud-eu/web#2513**: suppresses a false-positive "Folder already exists" dialog triggered when the zip's top-level folder name matches anything in the user's current folder. `data.zip` wraps its content in `data/`, which is the same name as the freshly-created extraction folder, so the dialog fires.

Once a published OpenCloud image bundles a web that contains both, drop `test.skip` and the merge-dialog dismissal block. Verified locally against an unbundled web build (override mounting `../web/dist`) that includes both PRs.

## Related Issue

- Fixes #293

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)