### PR TITLE
feat(importer): updates colors, bug fixes, 2.0.0 release

### DIFF
--- a/packages/web-app-importer/CHANGELOG.md
+++ b/packages/web-app-importer/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## [2.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/importer-v2.0.0) - 2026-08-26
+
+### Breaking changes
+
+- The extension is now bundled as ESM instead of AMD and only loads with OpenCloud versions >= 6.
+
+### ✨ Features
+
+- Align dashboard colors with oc colors [[#535](https://github.com/opencloud-eu/web-extensions/pull/535)]
+
+### 🐛 Bug Fixes
+
+- Remove unsupported `webdavCloudType` config [[#535](https://github.com/opencloud-eu/web-extensions/pull/535)]
+- Strip trailing slash from `companionUrl` [[#535](https://github.com/opencloud-eu/web-extensions/pull/535)]
+
+## [1.0.0](https://github.com/opencloud-eu/web-extensions/releases/tag/importer-v1.0.0) - 2025-02-26
+
+### ✨ Features
+
+- Publish importer app [[#33](https://github.com/opencloud-eu/web-extensions/pull/33)]

--- a/packages/web-app-importer/README.md
+++ b/packages/web-app-importer/README.md
@@ -3,7 +3,7 @@
 This application can be used for importing files and folders from other sources directly into your OpenCloud. The following sources are currently supported:
 
 - Google Drive
-- Onedrive
+- OneDrive
 - OpenCloud (via public links without password)
 - NextCloud (via public links without password)
 
@@ -18,14 +18,12 @@ The `docker-compose.yml` in this repository includes a full working example of t
 ```
 "config": {
   "companionUrl": "https://example.com",
-  "supportedClouds": ['OneDrive', 'GoogleDrive', 'WebdavPublicLink'],
-  "webdavCloudType": "opencloud"
+  "supportedClouds": ['OneDrive', 'GoogleDrive', 'WebdavPublicLink']
 }
 ```
 
 - `companionUrl` _(string)_ - specifies the URL under which Companion can be reached. This config needs to be set.
 - `supportedClouds` _(list[string])_ - specifies the supported cloud sources from which a user can import. Defaults to all enabled.
-- `webdavCloudType` _(string)_ - limit the webdav import to either `opencloud` or `nextcloud`. Defaults to allowing both.
 
 ## CSP requirements
 

--- a/packages/web-app-importer/package.json
+++ b/packages/web-app-importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-app-importer",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "OpenCloud Web importer",
   "license": "AGPL-3.0",

--- a/packages/web-app-importer/src/composables/useExtensions.ts
+++ b/packages/web-app-importer/src/composables/useExtensions.ts
@@ -30,7 +30,7 @@ export const useExtensions = ({ applicationConfig }: ApplicationSetupOptions) =>
   const resourcesStore = useResourcesStore()
   const { currentFolder } = storeToRefs(resourcesStore)
 
-  const { companionUrl } = applicationConfig
+  const companionUrl = (applicationConfig.companionUrl as string)?.replace(/\/+$/, '')
   let { supportedClouds } = applicationConfig
   supportedClouds = supportedClouds || ['OneDrive', 'GoogleDrive', 'WebdavPublicLink']
 

--- a/packages/web-app-importer/src/composables/useExtensions.ts
+++ b/packages/web-app-importer/src/composables/useExtensions.ts
@@ -30,7 +30,7 @@ export const useExtensions = ({ applicationConfig }: ApplicationSetupOptions) =>
   const resourcesStore = useResourcesStore()
   const { currentFolder } = storeToRefs(resourcesStore)
 
-  const { companionUrl, webdavCloudType } = applicationConfig
+  const { companionUrl } = applicationConfig
   let { supportedClouds } = applicationConfig
   supportedClouds = supportedClouds || ['OneDrive', 'GoogleDrive', 'WebdavPublicLink']
 
@@ -118,8 +118,7 @@ export const useExtensions = ({ applicationConfig }: ApplicationSetupOptions) =>
       uppyService.addPlugin(Webdav, {
         target: Dashboard as any,
         id: 'WebdavPublicLink',
-        companionUrl,
-        ...(webdavCloudType && { cloudType: webdavCloudType })
+        companionUrl
       })
     }
   }

--- a/packages/web-app-importer/src/index.ts
+++ b/packages/web-app-importer/src/index.ts
@@ -2,6 +2,7 @@ import { useGettext } from 'vue3-gettext'
 import translations from '../l10n/translations.json'
 import { defineWebApplication } from '@opencloud-eu/web-pkg'
 import { useExtensions } from './composables/useExtensions'
+import './styles.css'
 
 export default defineWebApplication({
   setup(args) {

--- a/packages/web-app-importer/src/styles.css
+++ b/packages/web-app-importer/src/styles.css
@@ -1,0 +1,39 @@
+.uppy-Dashboard .uppy-DashboardTab-btn {
+  display: flex;
+}
+
+.uppy-Dashboard .uppy-Dashboard-inner {
+  border: var(--oc-role-outline-variant) 1px solid;
+  background: var(--oc-role-surface-container);
+}
+
+.uppy-Dashboard .uppy-c-textInput {
+  border: 1px var(--oc-role-outline) solid;
+  padding: calc(var(--spacing) * 2);
+  border-radius: var(--spacing);
+}
+
+.uppy-Dashboard .uppy-c-btn {
+  cursor: pointer;
+}
+
+.uppy-Dashboard .uppy-c-btn-primary {
+  border: 1px var(--oc-role-outline) solid;
+  background: var(--oc-role-secondary);
+  color: var(--oc-role-on-secondary);
+  padding: calc(var(--spacing) * 2);
+  border-radius: var(--spacing);
+}
+
+.uppy-Dashboard .uppy-Dashboard-AddFiles-info {
+  width: 100%;
+}
+
+.uppy-Dashboard .uppy-Dashboard-AddFiles-info a {
+  gap: var(--spacing);
+}
+
+.uppy-Dashboard .uppy-Dashboard-AddFiles-info a,
+.uppy-Dashboard .uppy-Dashboard-AddFiles-info a > span {
+  display: inline-flex;
+}


### PR DESCRIPTION
Align the Uppy dashboard colors with our oc colors, remove the unsupported `webdavCloudType` config, strip trailing slashes from `companionUrl` because it breaks things and prepares the `v2.0.0` release. Apparently, this app has never been released since we switched to ESM.