### PR TITLE
Add web-app-desktop-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains a collection of [OpenCloud Web](https://github.com/open
 - [web-app-bpmn](./packages/web-app-bpmn/)
 - [web-app-calculator](./packages/web-app-calculator/)
 - [web-app-cast](./packages/web-app-cast/)
+- [web-app-desktop-bridge](./packages/web-app-desktop-bridge/)
 - [web-app-draw-io](./packages/web-app-draw-io/)
 - [web-app-external-sites](./packages/web-app-external-sites/)
 - [web-app-importer](./packages/web-app-importer/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - ./packages/web-app-arcade/dist:/web/apps/arcade
       - ./packages/web-app-cast/dist:/web/apps/cast
       - ./packages/web-app-bpmn/dist:/web/apps/bpmn
+      - ./packages/web-app-desktop-bridge/dist:/web/apps/desktop-bridge
       - ./packages/web-app-draw-io/dist:/web/apps/draw-io
       - ./packages/web-app-external-sites/dist:/web/apps/external-sites
       - ./packages/web-app-importer/dist:/web/apps/importer

--- a/packages/web-app-desktop-bridge/CHANGELOG.md
+++ b/packages/web-app-desktop-bridge/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (unreleased)
+
+### ✨ Features
+
+- Initial release: announce the logged-in portal to the ONLYOFFICE desktop app
+  (`portal:login`), so OpenCloud appears and persists in the app's Clouds list

--- a/packages/web-app-desktop-bridge/README.md
+++ b/packages/web-app-desktop-bridge/README.md
@@ -1,0 +1,35 @@
+# web-app-desktop-bridge
+
+Announces the logged-in OpenCloud portal to the ONLYOFFICE desktop app, so the
+portal shows up (and persists) in the app's **Clouds** list.
+
+The desktop app only lists a connected cloud when the portal page itself calls
+`AscDesktopEditor.execCommand('portal:login', ...)`. On Nextcloud and ownCloud
+this is done by the ONLYOFFICE connector app. OpenCloud needs no connector for
+the editors themselves — WOPI and the built-in collaboration service cover that
+natively — so this small extension provides just the missing announcement.
+
+Outside the desktop app (no `window.AscDesktopEditor` present) the extension
+does nothing.
+
+## How it works
+
+On startup, when running inside the desktop app's browser shell, the extension
+waits for the authenticated user to land in the runtime's user store and then
+announces the portal once:
+
+```js
+AscDesktopEditor.execCommand('portal:login', JSON.stringify({
+  displayName, // user's display name, falling back to the account name
+  domain,      // window.location.origin
+  provider: 'opencloud'
+}))
+```
+
+The payload deliberately mirrors the Nextcloud connector's payload — in
+particular it carries no `email` field, since the desktop app's start page
+compares that field against its stored portal entry and silently drops the
+event on mismatch.
+
+Requires a desktop app that knows the `opencloud` provider (an `opencloud`
+entry in the app's `providers/` directory).

--- a/packages/web-app-desktop-bridge/extension.d.ts
+++ b/packages/web-app-desktop-bridge/extension.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/web-app-desktop-bridge/package.json
+++ b/packages/web-app-desktop-bridge/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "web-app-desktop-bridge",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Announce the logged-in OpenCloud portal to the ONLYOFFICE desktop app, so it appears in its Clouds list",
+  "license": "AGPL-3.0",
+  "type": "module",
+  "scripts": {
+    "build": "pnpm vite build",
+    "build:w": "pnpm vite build --watch --mode development",
+    "check:types": "vue-tsc --noEmit",
+    "test:unit": "NODE_OPTIONS=--unhandled-rejections=throw vitest"
+  },
+  "devDependencies": {
+    "@opencloud-eu/web-pkg": "^7.0.0",
+    "vue": "^3.4.21"
+  }
+}

--- a/packages/web-app-desktop-bridge/src/index.ts
+++ b/packages/web-app-desktop-bridge/src/index.ts
@@ -1,0 +1,72 @@
+import { defineWebApplication, useUserStore } from '@opencloud-eu/web-pkg'
+import { watch } from 'vue'
+
+// The ONLYOFFICE / Euro-Office desktop shell only lists a connected portal in
+// its "Clouds" panel when the portal page itself announces the login via
+// AscDesktopEditor.execCommand('portal:login', ...) — in Nextcloud the
+// ONLYOFFICE connector app does this (src/desktop.js). OpenCloud has no
+// connector, so this extension fills that role. Outside the desktop shell
+// (no window.AscDesktopEditor) it does nothing.
+
+declare global {
+  interface Window {
+    AscDesktopEditor?: { execCommand: (command: string, arg: string) => void }
+    __ocDesktopBridgeAnnounced?: boolean
+  }
+}
+
+export default defineWebApplication({
+  setup() {
+    if (window.AscDesktopEditor) {
+      const userStore = useUserStore()
+
+      const announce = (): boolean => {
+        if (window.__ocDesktopBridgeAnnounced) {
+          return true
+        }
+        const user = userStore.user
+        // Prefer the human-readable name: deployments that autoprovision from the
+        // OIDC `sub` claim have opaque UUIDs as account names.
+        const displayName = user?.displayName || user?.onPremisesSamAccountName
+        if (!displayName) {
+          return false
+        }
+        // Mirror the Nextcloud connector's payload exactly: displayName,
+        // domain, provider — and nothing more. The start page's portal:login
+        // handler compares an `email` field against the session's portal
+        // model with no fallback on mismatch, so sending a real email
+        // silently drops the event.
+        window.AscDesktopEditor.execCommand(
+          'portal:login',
+          JSON.stringify({
+            displayName,
+            domain: window.location.origin,
+            provider: 'opencloud'
+          })
+        )
+        window.__ocDesktopBridgeAnnounced = true
+        return true
+      }
+
+      // The user lands in the store shortly after the OIDC callback, so watch
+      // for it instead of assuming it is present at app boot.
+      if (!announce()) {
+        const stop = watch(
+          () => userStore.user,
+          () => {
+            if (announce()) {
+              stop()
+            }
+          }
+        )
+      }
+    }
+
+    return {
+      appInfo: {
+        id: 'desktop-bridge',
+        name: 'Desktop Bridge'
+      }
+    }
+  }
+})

--- a/packages/web-app-desktop-bridge/tests/unit/App.spec.ts
+++ b/packages/web-app-desktop-bridge/tests/unit/App.spec.ts
@@ -1,0 +1,79 @@
+import { reactive } from 'vue'
+
+type User = { displayName?: string; onPremisesSamAccountName?: string; mail?: string }
+
+const userStore = reactive({ user: null as User | null })
+
+vi.mock('@opencloud-eu/web-pkg', () => ({
+  defineWebApplication: (app: unknown) => app,
+  useUserStore: () => userStore
+}))
+
+import app from '../../src/index'
+
+const setup = () => (app as { setup: () => { appInfo: { id: string } } }).setup()
+
+describe('desktop-bridge', () => {
+  let execCommand: ReturnType<typeof vi.fn<(command: string, arg: string) => void>>
+
+  beforeEach(() => {
+    execCommand = vi.fn<(command: string, arg: string) => void>()
+    userStore.user = null
+    window.__ocDesktopBridgeAnnounced = undefined
+    window.AscDesktopEditor = { execCommand }
+  })
+
+  it('registers the app but does nothing outside the desktop shell', () => {
+    window.AscDesktopEditor = undefined
+    userStore.user = { displayName: 'Alice' } as User
+
+    expect(setup().appInfo.id).toBe('desktop-bridge')
+    expect(execCommand).not.toHaveBeenCalled()
+  })
+
+  it('announces the portal once when the user is already known', () => {
+    userStore.user = { displayName: 'Alice', onPremisesSamAccountName: 'alice' } as User
+
+    setup()
+
+    expect(execCommand).toHaveBeenCalledTimes(1)
+    const [command, payload] = execCommand.mock.calls[0]
+    expect(command).toBe('portal:login')
+    expect(JSON.parse(payload)).toEqual({
+      displayName: 'Alice',
+      domain: window.location.origin,
+      provider: 'opencloud'
+    })
+  })
+
+  it('waits for the user to arrive, then announces exactly once', async () => {
+    setup()
+    expect(execCommand).not.toHaveBeenCalled()
+
+    userStore.user = { displayName: 'Alice' } as User
+    await nextTicks()
+    expect(execCommand).toHaveBeenCalledTimes(1)
+
+    userStore.user = { displayName: 'Someone Else' } as User
+    await nextTicks()
+    expect(execCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the account name when the display name is missing', () => {
+    userStore.user = { onPremisesSamAccountName: 'alice' } as User
+
+    setup()
+
+    expect(JSON.parse(execCommand.mock.calls[0][1]).displayName).toBe('alice')
+  })
+
+  it('never includes an email field in the payload', () => {
+    userStore.user = { displayName: 'Alice', mail: 'alice@example.org' } as User
+
+    setup()
+
+    expect(JSON.parse(execCommand.mock.calls[0][1])).not.toHaveProperty('email')
+  })
+})
+
+const nextTicks = () => new Promise((resolve) => setTimeout(resolve, 0))

--- a/packages/web-app-desktop-bridge/tsconfig.json
+++ b/packages/web-app-desktop-bridge/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/web-app-desktop-bridge/vite.config.ts
+++ b/packages/web-app-desktop-bridge/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@opencloud-eu/extension-sdk'
+
+export default defineConfig({
+  name: 'desktop-bridge'
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,10 +14,10 @@ importers:
     devDependencies:
       '@opencloud-eu/eslint-config':
         specifier: ^7.0.0
-        version: 7.3.0(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
+        version: 7.3.0(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)))
       '@opencloud-eu/extension-sdk':
         specifier: 7.3.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(node-fetch@3.3.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0)))(vue-tsc@3.3.9(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0)))(vue-tsc@3.3.9(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
       '@opencloud-eu/prettier-config':
         specifier: ^7.0.0
         version: 7.3.0(prettier@3.9.6)
@@ -26,7 +26,7 @@ importers:
         version: 7.3.0
       '@opencloud-eu/web-test-helpers':
         specifier: ^7.0.0
-        version: 7.3.0(6ff60f1986edbe3c143088ad34a85f0b)
+        version: 7.3.0(281baa91018131ab96842f74463f965a)
       '@playwright/test':
         specifier: ^1.50.1
         version: 1.62.1
@@ -41,7 +41,7 @@ importers:
         version: 2.4.11(@vue/compiler-dom@3.5.41)(@vue/server-renderer@3.5.41)(vue@3.5.41(typescript@6.0.3))
       eslint:
         specifier: ^10.1.0
-        version: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+        version: 10.8.0(jiti@2.7.0)
       happy-dom:
         specifier: ^20.0.0
         version: 20.11.1
@@ -83,25 +83,25 @@ importers:
     dependencies:
       '@emulatorjs/core-fceumm':
         specifier: 4.2.3
-        version: 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 4.2.3
       '@emulatorjs/core-gambatte':
         specifier: 4.2.3
-        version: 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 4.2.3
       '@emulatorjs/core-mgba':
         specifier: 4.2.3
-        version: 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 4.2.3
       '@emulatorjs/core-mupen64plus_next':
         specifier: 4.2.3
-        version: 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 4.2.3
       '@emulatorjs/core-snes9x':
         specifier: 4.2.3
-        version: 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 4.2.3
       '@emulatorjs/emulatorjs':
         specifier: ^4.2.3
-        version: 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 4.2.3
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
     devDependencies:
       vue:
         specifier: ^3.4.21
@@ -130,10 +130,10 @@ importers:
     devDependencies:
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       vue:
         specifier: ^3.4.21
         version: 3.5.41(typescript@6.0.3)
@@ -149,10 +149,10 @@ importers:
     devDependencies:
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@vueuse/core':
         specifier: ^14.0.0
         version: 14.4.0(vue@3.5.41(typescript@6.0.3))
@@ -167,10 +167,10 @@ importers:
     devDependencies:
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@types/chromecast-caf-sender':
         specifier: ^1.0.8
         version: 1.0.11
@@ -181,14 +181,23 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1(vue@3.5.41(typescript@6.0.3))
 
+  packages/web-app-desktop-bridge:
+    devDependencies:
+      '@opencloud-eu/web-pkg':
+        specifier: ^7.0.0
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+      vue:
+        specifier: ^3.4.21
+        version: 3.5.41(typescript@6.0.3)
+
   packages/web-app-draw-io:
     devDependencies:
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       qs:
         specifier: ^6.11.2
         version: 6.15.3
@@ -203,10 +212,10 @@ importers:
     devDependencies:
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       vue:
         specifier: ^3.4.21
         version: 3.5.41(typescript@6.0.3)
@@ -237,10 +246,10 @@ importers:
     devDependencies:
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@uppy/core':
         specifier: ^5.1.1
         version: 5.2.0
@@ -262,10 +271,10 @@ importers:
     devDependencies:
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       sass-embedded:
         specifier: ^1.98.0
         version: 1.100.0
@@ -280,10 +289,10 @@ importers:
     dependencies:
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@protomaps/basemaps':
         specifier: ^5.7.0
         version: 5.7.2
@@ -314,10 +323,10 @@ importers:
         version: 7.3.0(@vue/compiler-sfc@3.5.41)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
     devDependencies:
       pinia:
         specifier: ^4.0.0
@@ -343,10 +352,10 @@ importers:
     devDependencies:
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@vueuse/core':
         specifier: ^14.0.0
         version: 14.4.0(vue@3.5.41(typescript@6.0.3))
@@ -361,7 +370,7 @@ importers:
     devDependencies:
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@vueuse/core':
         specifier: ^14.0.0
         version: 14.4.0(vue@3.5.41(typescript@6.0.3))
@@ -380,10 +389,10 @@ importers:
     devDependencies:
       '@opencloud-eu/web-client':
         specifier: ^7.0.0
-        version: 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.3.0
       '@opencloud-eu/web-pkg':
         specifier: ^7.0.0
-        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       uuid:
         specifier: ^14.0.0
         version: 14.0.1
@@ -1852,11 +1861,6 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@vue-macros/common@3.1.4':
     resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
@@ -4601,9 +4605,9 @@ snapshots:
 
   '@emoji-mart/data@1.2.1': {}
 
-  '@emulatorjs/core-81@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-81@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4611,9 +4615,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-a5200@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-a5200@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4621,9 +4625,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-beetle_vb@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-beetle_vb@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4631,9 +4635,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-cap32@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-cap32@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4641,9 +4645,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-crocods@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-crocods@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4651,9 +4655,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-desmume2015@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-desmume2015@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4661,9 +4665,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-desmume@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-desmume@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4671,9 +4675,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-dosbox_pure@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-dosbox_pure@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4681,9 +4685,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-fbalpha2012_cps1@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-fbalpha2012_cps1@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4691,9 +4695,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-fbalpha2012_cps2@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-fbalpha2012_cps2@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4701,9 +4705,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-fbneo@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-fbneo@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4711,37 +4715,18 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-fceumm@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-fceumm@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@emulatorjs/core-fuse@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-fuse@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    optional: true
-
-  '@emulatorjs/core-gambatte@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
-  '@emulatorjs/core-gearcoleco@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4749,9 +4734,18 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-genesis_plus_gx@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-gambatte@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@emulatorjs/core-gearcoleco@4.2.3':
+    dependencies:
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4759,9 +4753,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-handy@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-genesis_plus_gx@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4769,9 +4763,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-mame2003@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-handy@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4779,9 +4773,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-mame2003_plus@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-mame2003@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4789,9 +4783,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-mednafen_ngp@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-mame2003_plus@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4799,9 +4793,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-mednafen_pce@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-mednafen_ngp@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4809,9 +4803,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-mednafen_pcfx@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-mednafen_pce@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4819,9 +4813,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-mednafen_psx_hw@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-mednafen_pcfx@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4829,9 +4823,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-mednafen_wswan@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-mednafen_psx_hw@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4839,9 +4833,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-melonds@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-mednafen_wswan@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4849,27 +4843,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-mgba@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-melonds@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
-  '@emulatorjs/core-mupen64plus_next@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
-  '@emulatorjs/core-nestopia@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4877,9 +4853,27 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-opera@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-mgba@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@emulatorjs/core-mupen64plus_next@4.2.3':
+    dependencies:
+      '@emulatorjs/emulatorjs': 4.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@emulatorjs/core-nestopia@4.2.3':
+    dependencies:
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4887,9 +4881,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-parallel_n64@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-opera@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4897,9 +4891,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-pcsx_rearmed@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-parallel_n64@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4907,9 +4901,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-picodrive@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-pcsx_rearmed@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4917,9 +4911,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-ppsspp@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-picodrive@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4927,9 +4921,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-prboom@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-ppsspp@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4937,9 +4931,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-prosystem@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-prboom@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4947,9 +4941,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-puae@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-prosystem@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4957,9 +4951,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-same_cdi@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-puae@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4967,9 +4961,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-smsplus@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-same_cdi@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4977,18 +4971,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-snes9x@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-smsplus@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
-  '@emulatorjs/core-stella2014@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -4996,9 +4981,18 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-vice_x128@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-snes9x@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@emulatorjs/core-stella2014@4.2.3':
+    dependencies:
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -5006,9 +5000,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-vice_x64@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-vice_x128@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -5016,9 +5010,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-vice_x64sc@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-vice_x64@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -5026,9 +5020,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-vice_xpet@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-vice_x64sc@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -5036,9 +5030,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-vice_xplus4@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-vice_xpet@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -5046,9 +5040,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-vice_xvic@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-vice_xplus4@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -5056,9 +5050,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-virtualjaguar@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-vice_xvic@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -5066,9 +5060,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/core-yabause@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-virtualjaguar@4.2.3':
     dependencies:
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -5076,57 +5070,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/cores@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/core-yabause@4.2.3':
     dependencies:
-      '@emulatorjs/core-81': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-a5200': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-beetle_vb': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-cap32': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-crocods': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-desmume': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-desmume2015': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-dosbox_pure': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-fbalpha2012_cps1': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-fbalpha2012_cps2': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-fbneo': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-fceumm': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-fuse': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-gambatte': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-gearcoleco': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-genesis_plus_gx': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-handy': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-mame2003': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-mame2003_plus': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-mednafen_ngp': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-mednafen_pce': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-mednafen_pcfx': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-mednafen_psx_hw': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-mednafen_wswan': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-melonds': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-mgba': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-mupen64plus_next': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-nestopia': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-opera': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-parallel_n64': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-pcsx_rearmed': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-picodrive': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-ppsspp': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-prboom': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-prosystem': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-puae': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-same_cdi': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-smsplus': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-snes9x': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-stella2014': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-vice_x128': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-vice_x64': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-vice_x64sc': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-vice_xpet': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-vice_xplus4': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-vice_xvic': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-virtualjaguar': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/core-yabause': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@emulatorjs/emulatorjs': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/emulatorjs': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -5134,35 +5080,93 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@emulatorjs/emulatorjs@4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@emulatorjs/cores@4.2.3':
+    dependencies:
+      '@emulatorjs/core-81': 4.2.3
+      '@emulatorjs/core-a5200': 4.2.3
+      '@emulatorjs/core-beetle_vb': 4.2.3
+      '@emulatorjs/core-cap32': 4.2.3
+      '@emulatorjs/core-crocods': 4.2.3
+      '@emulatorjs/core-desmume': 4.2.3
+      '@emulatorjs/core-desmume2015': 4.2.3
+      '@emulatorjs/core-dosbox_pure': 4.2.3
+      '@emulatorjs/core-fbalpha2012_cps1': 4.2.3
+      '@emulatorjs/core-fbalpha2012_cps2': 4.2.3
+      '@emulatorjs/core-fbneo': 4.2.3
+      '@emulatorjs/core-fceumm': 4.2.3
+      '@emulatorjs/core-fuse': 4.2.3
+      '@emulatorjs/core-gambatte': 4.2.3
+      '@emulatorjs/core-gearcoleco': 4.2.3
+      '@emulatorjs/core-genesis_plus_gx': 4.2.3
+      '@emulatorjs/core-handy': 4.2.3
+      '@emulatorjs/core-mame2003': 4.2.3
+      '@emulatorjs/core-mame2003_plus': 4.2.3
+      '@emulatorjs/core-mednafen_ngp': 4.2.3
+      '@emulatorjs/core-mednafen_pce': 4.2.3
+      '@emulatorjs/core-mednafen_pcfx': 4.2.3
+      '@emulatorjs/core-mednafen_psx_hw': 4.2.3
+      '@emulatorjs/core-mednafen_wswan': 4.2.3
+      '@emulatorjs/core-melonds': 4.2.3
+      '@emulatorjs/core-mgba': 4.2.3
+      '@emulatorjs/core-mupen64plus_next': 4.2.3
+      '@emulatorjs/core-nestopia': 4.2.3
+      '@emulatorjs/core-opera': 4.2.3
+      '@emulatorjs/core-parallel_n64': 4.2.3
+      '@emulatorjs/core-pcsx_rearmed': 4.2.3
+      '@emulatorjs/core-picodrive': 4.2.3
+      '@emulatorjs/core-ppsspp': 4.2.3
+      '@emulatorjs/core-prboom': 4.2.3
+      '@emulatorjs/core-prosystem': 4.2.3
+      '@emulatorjs/core-puae': 4.2.3
+      '@emulatorjs/core-same_cdi': 4.2.3
+      '@emulatorjs/core-smsplus': 4.2.3
+      '@emulatorjs/core-snes9x': 4.2.3
+      '@emulatorjs/core-stella2014': 4.2.3
+      '@emulatorjs/core-vice_x128': 4.2.3
+      '@emulatorjs/core-vice_x64': 4.2.3
+      '@emulatorjs/core-vice_x64sc': 4.2.3
+      '@emulatorjs/core-vice_xpet': 4.2.3
+      '@emulatorjs/core-vice_xplus4': 4.2.3
+      '@emulatorjs/core-vice_xvic': 4.2.3
+      '@emulatorjs/core-virtualjaguar': 4.2.3
+      '@emulatorjs/core-yabause': 4.2.3
+      '@emulatorjs/emulatorjs': 4.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+    optional: true
+
+  '@emulatorjs/emulatorjs@4.2.3':
     dependencies:
       '@node-minify/clean-css': 9.0.1
       '@node-minify/core': 9.0.2
       '@node-minify/terser': 9.0.1
-      http-server: 14.1.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      http-server: 14.1.1
       nipplejs: 0.10.2
-      node-7z: 3.0.0(supports-color@8.1.1)
+      node-7z: 3.0.0
       node-fetch: 3.3.2
-      socket.io: 4.8.3(supports-color@8.1.1)
+      socket.io: 4.8.3
     optionalDependencies:
-      '@emulatorjs/cores': 4.2.3(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@emulatorjs/cores': 4.2.3
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0(jiti@2.7.0))':
     dependencies:
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.8.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5(supports-color@8.1.1)':
+  '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 10.2.6
     transitivePeerDependencies:
       - supports-color
@@ -5339,7 +5343,7 @@ snapshots:
 
   '@microsoft/fetch-event-source@2.0.1': {}
 
-  '@module-federation/dts-plugin@2.3.1(debug@4.4.3(supports-color@8.1.1))(node-fetch@3.3.2)(supports-color@8.1.1)(typescript@6.0.3)(vue-tsc@3.3.9(typescript@6.0.3))':
+  '@module-federation/dts-plugin@2.3.1(node-fetch@3.3.2)(typescript@6.0.3)(vue-tsc@3.3.9(typescript@6.0.3))':
     dependencies:
       '@module-federation/error-codes': 2.3.1
       '@module-federation/managers': 2.3.1(node-fetch@3.3.2)
@@ -5347,7 +5351,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 2.3.1
       adm-zip: 0.5.18
       ansi-colors: 4.1.3
-      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios: 1.19.0
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
       node-schedule: 2.1.1
@@ -5397,9 +5401,9 @@ snapshots:
       fs-extra: 9.1.0
       resolve: 1.22.8
 
-  '@module-federation/vite@1.14.2(debug@4.4.3(supports-color@8.1.1))(node-fetch@3.3.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@6.0.3))':
+  '@module-federation/vite@1.14.2(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@6.0.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.3.1(debug@4.4.3(supports-color@8.1.1))(node-fetch@3.3.2)(supports-color@8.1.1)(typescript@6.0.3)(vue-tsc@3.3.9(typescript@6.0.3))
+      '@module-federation/dts-plugin': 2.3.1(node-fetch@3.3.2)(typescript@6.0.3)(vue-tsc@3.3.9(typescript@6.0.3))
       '@module-federation/runtime': 2.3.1(node-fetch@3.3.2)
       '@module-federation/sdk': 2.3.1(node-fetch@3.3.2)
       '@rollup/pluginutils': 5.4.0
@@ -5474,24 +5478,24 @@ snapshots:
       - vue
       - webpack
 
-  '@opencloud-eu/eslint-config@7.3.0(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))':
+  '@opencloud-eu/eslint-config@7.3.0(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)))':
     dependencies:
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
-      eslint-config-prettier: 10.1.8(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
-      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
-      eslint-plugin-vue: 10.10.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)
+      eslint-config-prettier: 10.1.8(eslint@10.8.0(jiti@2.7.0))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))
+      eslint-plugin-vue: 10.10.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)))
       typescript: 6.0.3
-      typescript-eslint: 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      typescript-eslint: 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - '@stylistic/eslint-plugin'
       - '@typescript-eslint/eslint-plugin'
       - supports-color
       - vue-eslint-parser
 
-  '@opencloud-eu/extension-sdk@7.3.0(debug@4.4.3(supports-color@8.1.1))(node-fetch@3.3.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0)))(vue-tsc@3.3.9(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))':
+  '@opencloud-eu/extension-sdk@7.3.0(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0)))(vue-tsc@3.3.9(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      '@module-federation/vite': 1.14.2(debug@4.4.3(supports-color@8.1.1))(node-fetch@3.3.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@6.0.3))
+      '@module-federation/vite': 1.14.2(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@6.0.3))
       '@tailwindcss/vite': 4.3.3(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))
       '@vitejs/plugin-basic-ssl': 2.3.0(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
@@ -5514,11 +5518,11 @@ snapshots:
 
   '@opencloud-eu/tsconfig@7.3.0': {}
 
-  '@opencloud-eu/web-client@7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@opencloud-eu/web-client@7.3.0':
     dependencies:
       '@casl/ability': 7.0.1
       '@microsoft/fetch-event-source': 2.0.1
-      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios: 1.19.0
       fast-xml-parser: 5.10.1
       lodash-es: 4.18.1
       luxon: 3.7.2
@@ -5529,13 +5533,13 @@ snapshots:
       - debug
       - supports-color
 
-  '@opencloud-eu/web-pkg@7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
+  '@opencloud-eu/web-pkg@7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@casl/ability': 7.0.1
       '@casl/vue': 3.0.1(@casl/ability@7.0.1)(vue@3.5.41(typescript@6.0.3))
       '@microsoft/fetch-event-source': 2.0.1
       '@opencloud-eu/design-system': 7.3.0(@vue/compiler-sfc@3.5.41)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
-      '@opencloud-eu/web-client': 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@opencloud-eu/web-client': 7.3.0
       '@sentry/vue': 10.69.0(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(vue@3.5.41(typescript@6.0.3))
       '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
       '@tiptap/extension-document': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
@@ -5566,7 +5570,7 @@ snapshots:
       '@uppy/xhr-upload': 5.2.0(@uppy/core@5.2.0)
       '@vue/shared': 3.5.41
       '@vueuse/core': 14.4.0(vue@3.5.41(typescript@6.0.3))
-      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios: 1.19.0
       cropperjs: 2.1.1
       deepmerge: 4.3.1
       dompurify: 3.4.13
@@ -5613,16 +5617,16 @@ snapshots:
       - vue
       - webpack
 
-  '@opencloud-eu/web-test-helpers@7.3.0(6ff60f1986edbe3c143088ad34a85f0b)':
+  '@opencloud-eu/web-test-helpers@7.3.0(281baa91018131ab96842f74463f965a)':
     dependencies:
       '@casl/ability': 7.0.1
       '@casl/vue': 3.0.1(@casl/ability@7.0.1)(vue@3.5.41(typescript@6.0.3))
       '@opencloud-eu/design-system': 7.3.0(@vue/compiler-sfc@3.5.41)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
-      '@opencloud-eu/web-client': 7.3.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@opencloud-eu/web-pkg': 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(debug@4.4.3(supports-color@8.1.1))(rolldown@1.2.2)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+      '@opencloud-eu/web-client': 7.3.0
+      '@opencloud-eu/web-pkg': 7.3.0(@floating-ui/dom@1.8.0)(@tiptap/extension-collaboration@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-list@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/extensions@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(@vue/compiler-sfc@3.5.41)(@vue/devtools-api@8.2.1)(rolldown@1.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@pinia/testing': 2.0.1(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))
       '@vue/test-utils': 2.4.11(@vue/compiler-dom@3.5.41)(@vue/server-renderer@3.5.41)(vue@3.5.41(typescript@6.0.3))
-      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios: 1.19.0
       pinia: 4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
       vitest-mock-extended: 5.1.1(typescript@6.0.3)(vitest@4.1.10(@types/node@24.13.3)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.36.0)(yaml@2.9.0)))
       vue: 3.5.41(typescript@6.0.3)
@@ -6215,15 +6219,15 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
-  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.66.0
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.8.0(jiti@2.7.0)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -6231,23 +6235,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.66.0
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      debug: 4.4.3
+      eslint: 10.8.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.66.0(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.66.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6261,13 +6265,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.8.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6275,13 +6279,13 @@ snapshots:
 
   '@typescript-eslint/types@8.66.0': {}
 
-  '@typescript-eslint/typescript-estree@8.66.0(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.66.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.66.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.66.0(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/visitor-keys': 8.66.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -6290,13 +6294,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6492,13 +6496,11 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28(typescript@6.0.3)':
+  '@volar/typescript@2.4.28':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
-    optionalDependencies:
-      typescript: 6.0.3
 
   '@vue-macros/common@3.1.4(vue@3.5.41(typescript@6.0.3))':
     dependencies:
@@ -6630,9 +6632,9 @@ snapshots:
 
   adm-zip@0.5.18: {}
 
-  agent-base@6.0.2(supports-color@8.1.1):
+  agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6693,11 +6695,11 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  axios@1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+  axios@1.19.0:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -6896,11 +6898,9 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  debug@4.4.3(supports-color@8.1.1):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
   decimal.js@10.6.0: {}
 
@@ -6981,7 +6981,7 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.9(supports-color@8.1.1):
+  engine.io@6.6.9:
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 24.13.3
@@ -6990,7 +6990,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       engine.io-parser: 5.2.3
       ws: 8.21.2
     transitivePeerDependencies:
@@ -7028,28 +7028,28 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1)):
+  eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.8.0(jiti@2.7.0)
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1)):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.8.0(jiti@2.7.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
 
-  eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)):
+  eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
+      eslint: 10.8.0(jiti@2.7.0)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.4
       semver: 7.8.5
-      vue-eslint-parser: 10.4.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      vue-eslint-parser: 10.4.1(eslint@10.8.0(jiti@2.7.0))
       xml-name-validator: 5.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -7062,11 +7062,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1):
+  eslint@10.8.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
+      '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -7076,7 +7076,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -7215,9 +7215,7 @@ snapshots:
     dependencies:
       tabbable: 6.5.0
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -7367,26 +7365,26 @@ snapshots:
     dependencies:
       whatwg-encoding: 2.0.0
 
-  http-proxy@1.18.1(debug@4.4.3(supports-color@8.1.1)):
+  http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
 
-  http-server@14.1.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+  http-server@14.1.1:
     dependencies:
       basic-auth: 2.0.1
       chalk: 4.1.2
       corser: 2.0.1
       he: 1.2.0
       html-encoding-sniffer: 3.0.0
-      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
+      http-proxy: 1.18.1
       mime: 1.6.0
       minimist: 1.2.8
       opener: 1.5.2
-      portfinder: 1.0.38(supports-color@8.1.1)
+      portfinder: 1.0.38
       secure-compare: 3.0.1
       union: 0.5.0
       url-join: 4.0.1
@@ -7394,10 +7392,10 @@ snapshots:
       - debug
       - supports-color
 
-  https-proxy-agent@5.0.1(supports-color@8.1.1):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      agent-base: 6.0.2
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7832,9 +7830,9 @@ snapshots:
 
   nipplejs@0.10.2: {}
 
-  node-7z@3.0.0(supports-color@8.1.1):
+  node-7z@3.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       lodash.defaultsdeep: 4.6.1
       lodash.defaultto: 4.14.0
       lodash.flattendeep: 4.4.0
@@ -8006,10 +8004,10 @@ snapshots:
 
   pofile@1.1.4: {}
 
-  portfinder@1.0.38(supports-color@8.1.1):
+  portfinder@1.0.38:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8334,31 +8332,31 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  socket.io-adapter@2.5.8(supports-color@8.1.1):
+  socket.io-adapter@2.5.8:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.7(supports-color@8.1.1):
+  socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.8.3(supports-color@8.1.1):
+  socket.io@4.8.3:
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.6
-      debug: 4.4.3(supports-color@8.1.1)
-      engine.io: 6.6.9(supports-color@8.1.1)
-      socket.io-adapter: 2.5.8(supports-color@8.1.1)
-      socket.io-parser: 4.2.7(supports-color@8.1.1)
+      debug: 4.4.3
+      engine.io: 6.6.9
+      socket.io-adapter: 2.5.8
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8516,13 +8514,13 @@ snapshots:
 
   typed-function@4.2.2: {}
 
-  typescript-eslint@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3):
+  typescript-eslint@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -8672,10 +8670,10 @@ snapshots:
       caf: 15.0.1
       vue: 3.5.41(typescript@6.0.3)
 
-  vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+  vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
+      debug: 4.4.3
+      eslint: 10.8.0(jiti@2.7.0)
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0
@@ -8729,7 +8727,7 @@ snapshots:
 
   vue-tsc@3.3.9(typescript@6.0.3):
     dependencies:
-      '@volar/typescript': 2.4.28(typescript@6.0.3)
+      '@volar/typescript': 2.4.28
       '@vue/language-core': 3.3.9
       typescript: 6.0.3
 


### PR DESCRIPTION
## Description

Adds `web-app-desktop-bridge`, a small extension that makes connected OpenCloud
portals show up (and persist) in the ONLYOFFICE desktop app's **Clouds** list.

**Note on scope:** this extension is one half of the integration. The other
half is an `opencloud` provider entry in the desktop app's `providers/`
directory — without it, the desktop app drops the announcement as coming from
an unknown provider and this extension is effectively a no-op. No shipped
desktop build includes that entry yet; it can be added to an installed app by
dropping a provider directory into `<install dir>/providers/` (enumerated at
startup, no rebuild), and it is being proposed to the desktop app projects
(ref. ONLYOFFICE/DesktopEditors#2047).

The desktop app only remembers a connected cloud when the portal page itself
announces the login via `AscDesktopEditor.execCommand('portal:login', ...)`.
On Nextcloud/ownCloud the ONLYOFFICE connector app does this. OpenCloud needs
no connector for the editors — WOPI and the built-in collaboration service
cover that natively — so connected OpenCloud portals were never remembered by
the desktop app.

This extension provides just the missing announcement: inside the desktop
app's shell it waits for the authenticated user in the runtime's user store
(`useUserStore`), then announces the portal once with the same payload shape
as the Nextcloud connector — deliberately without an `email` field, since the
desktop start page silently drops the event on email mismatch. The display
name is preferred over the account name because deployments that autoprovision
usernames from the OIDC `sub` claim have opaque UUIDs as account names.
Outside the desktop app (no `window.AscDesktopEditor`) the extension does
nothing.

No user-facing strings, hence no l10n. Note: `pnpm-lock.yaml` was regenerated
with pnpm 10 — happy to regenerate with pnpm 11 if CI prefers.

## Related Issue

No existing issue in this repository. Companion change: an `opencloud` provider
entry for the desktop app itself, proposed separately to the desktop app
projects (ref. ONLYOFFICE/DesktopEditors#2047).

## How Has This Been Tested?

- test environment: OpenCloud 7.5.0 (rolling, opencloud-compose) behind an
  external reverse proxy with an external IdP; ONLYOFFICE DesktopEditors
  (arm64 .deb) with an `opencloud` entry in its `providers/` directory
- test case 1: log in to the portal inside the desktop app → the portal
  appears in the Clouds list with the user's display name
- test case 2: restart the desktop app → the portal entry persists; it can be
  removed from the list
- test case 3: open the same OpenCloud instance in a regular browser → the
  extension loads and does nothing 


## Types of changes

- [ ] Bugfix
- [x] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [x] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)